### PR TITLE
add interface for execution failure

### DIFF
--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -7,6 +7,7 @@ use crate::util::string;
 use crate::util::{Range, Spot, range};
 use source_reader::SourceReader;
 
+/// A lexer to produce tokens from a source.
 struct Lexer<'a> {
     reader: SourceReader<'a>,
 }

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -97,11 +97,9 @@ impl<'a> Lexer<'a> {
     }
 }
 
-pub fn lex<'a>(_source: &str) -> Result<Vec<Token>, LexErr<'a>> {
-    // fake implementation
-    // return dummy token
-    let fake_location = Range::new(Spot::new(0, 0), Spot::new(0, 0));
-    Ok(vec![Token::new(TokenKind::Number(1.0), fake_location)])
+pub fn lex<'a>(source: &'a str) -> Result<Vec<Token>, LexErr<'a>> {
+    let tokens = Lexer::new(source).lex()?;
+    Ok(tokens)
 }
 
 #[cfg(test)]
@@ -144,6 +142,16 @@ mod tests {
         let token = Lexer::new(source).lex();
 
         assert!(matches!(token, Err(LexErr::BadNumLiteral(_, _))));
+        Ok(())
+    }
+
+    #[test]
+    fn lex_fail() -> Result<(), Box<dyn Error>> {
+        let source = " ";
+
+        let token = Lexer::new(source).lex();
+
+        assert!(matches!(token, Err(LexErr::IllegalChar(_, _))));
         Ok(())
     }
 }

--- a/src/core/engine/lexer/source_reader/mod.rs
+++ b/src/core/engine/lexer/source_reader/mod.rs
@@ -1,0 +1,186 @@
+use super::utf8_tape::Utf8Tape;
+use crate::util::{Spot, Tape};
+
+pub struct SourceReader<'a> {
+    tape: Utf8Tape<'a>,
+    col: u64,
+    row: u64,
+}
+
+impl<'a> SourceReader<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            tape: Utf8Tape::new(source),
+            col: 0,
+            row: 0,
+        }
+    }
+
+    pub fn read(&self) -> Option<&'a str> {
+        match self.tape.get_current() {
+            Some("\r") => match self.tape.peak_next() {
+                Some("\n") => Some("\r\n"),
+                _ => Some("\r"),
+            },
+            x => x,
+        }
+    }
+
+    pub fn advance(&mut self) -> () {
+        match self.read() {
+            Some("\r") | Some("\n") => {
+                self.row += 1;
+                self.col = 0;
+                self.tape.advance();
+            }
+            Some("\r\n") => {
+                self.row += 1;
+                self.col = 0;
+                self.tape.advance();
+                self.tape.advance();
+            }
+            None => {}
+            _ => {
+                self.col += 1;
+                self.tape.advance();
+            }
+        }
+    }
+
+    pub fn spot(&self) -> Spot {
+        Spot::new(self.row, self.col)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read() {
+        let source = "ab";
+        let reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("a"));
+    }
+
+    #[test]
+    fn test_read_twice() {
+        let source = "ab";
+        let reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("a"));
+        assert_eq!(reader.read(), Some("a"));
+    }
+
+    #[test]
+    fn test_read_empty() {
+        let source = "";
+        let reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), None);
+    }
+
+    #[test]
+    fn test_advance() {
+        let source = "ab";
+        let mut reader = SourceReader::new(source);
+
+        reader.advance();
+        assert_eq!(reader.read(), Some("b"));
+    }
+
+    #[test]
+    fn test_read_lf() {
+        let source = "\n\n";
+        let mut reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("\n"));
+        assert_eq!(reader.read(), Some("\n"));
+        reader.advance();
+        assert_eq!(reader.read(), Some("\n"));
+        assert_eq!(reader.read(), Some("\n"));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+    }
+
+    #[test]
+    fn test_read_cr() {
+        let source = "\r\r";
+        let mut reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("\r"));
+        assert_eq!(reader.read(), Some("\r"));
+        reader.advance();
+        assert_eq!(reader.read(), Some("\r"));
+        assert_eq!(reader.read(), Some("\r"));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+    }
+
+    #[test]
+    fn test_read_crlf() {
+        let source = "\r\n\r\n";
+        let mut reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("\r\n"));
+        assert_eq!(reader.read(), Some("\r\n"));
+        reader.advance();
+        assert_eq!(reader.read(), Some("\r\n"));
+        assert_eq!(reader.read(), Some("\r\n"));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+    }
+
+    #[test]
+    fn test_spot_col() {
+        let source = "ab";
+        let mut reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("a"));
+        assert_eq!(reader.spot(), Spot::new(0, 0));
+        reader.advance();
+        assert_eq!(reader.read(), Some("b"));
+        assert_eq!(reader.spot(), Spot::new(0, 1));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+        assert_eq!(reader.spot(), Spot::new(0, 2));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+        assert_eq!(reader.spot(), Spot::new(0, 2));
+    }
+
+    #[test]
+    fn test_spot_row() {
+        let source = "\r\n\n\r";
+        let mut reader = SourceReader::new(source);
+
+        assert_eq!(reader.read(), Some("\r\n"));
+        assert_eq!(reader.spot(), Spot::new(0, 0));
+        reader.advance();
+        assert_eq!(reader.read(), Some("\n"));
+        assert_eq!(reader.spot(), Spot::new(1, 0));
+        reader.advance();
+        assert_eq!(reader.read(), Some("\r"));
+        assert_eq!(reader.spot(), Spot::new(2, 0));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+        assert_eq!(reader.spot(), Spot::new(3, 0));
+        reader.advance();
+        assert_eq!(reader.read(), None);
+        assert_eq!(reader.spot(), Spot::new(3, 0));
+    }
+
+    #[test]
+    fn test_spot_col_reset() {
+        let source = "a\r\nb";
+        let mut reader = SourceReader::new(source);
+
+        reader.advance();
+        assert_eq!(reader.read(), Some("\r\n"));
+        assert_eq!(reader.spot(), Spot::new(0, 1));
+        reader.advance();
+        assert_eq!(reader.read(), Some("b"));
+        assert_eq!(reader.spot(), Spot::new(1, 0));
+    }
+}

--- a/src/core/engine/lexer/source_reader/mod.rs
+++ b/src/core/engine/lexer/source_reader/mod.rs
@@ -1,6 +1,8 @@
 use super::utf8_tape::Utf8Tape;
 use crate::util::{Spot, Tape};
 
+/// A character reader from a source.
+/// It reads characters one by one, but treats CRLF ("\r\n") as a single character.
 pub struct SourceReader<'a> {
     tape: Utf8Tape<'a>,
     col: u64,

--- a/src/core/engine/lexer/utf8_tape/mod.rs
+++ b/src/core/engine/lexer/utf8_tape/mod.rs
@@ -1,0 +1,119 @@
+use crate::util::Tape;
+
+pub struct Utf8Tape<'a> {
+    chars: Vec<&'a str>,
+    base_index: usize,
+}
+
+impl<'a> Utf8Tape<'a> {
+    pub fn new(source: &'a str) -> Self {
+        let mut chars: Vec<&str> = vec![];
+        let mut base: usize = 0;
+
+        for c in source.chars() {
+            let size: usize = c.len_utf8();
+            let s: &str = &source[base..(base + size)];
+
+            chars.push(s);
+
+            base += size;
+        }
+
+        Self {
+            chars,
+            base_index: 0,
+        }
+    }
+}
+
+impl<'a> Tape for Utf8Tape<'a> {
+    type Item = &'a str;
+
+    fn get_current(&self) -> Option<Self::Item> {
+        self.chars.get(self.base_index).map(|s| *s)
+    }
+    fn peak_next(&self) -> Option<Self::Item> {
+        self.chars.get(self.base_index + 1).map(|s| *s)
+    }
+    fn advance(&mut self) -> () {
+        if self.base_index == self.chars.len() {
+            return ();
+        }
+
+        self.base_index += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_current_for_empty() {
+        let source = "";
+
+        let tape = Utf8Tape::new(&source);
+
+        assert_eq!(tape.get_current(), None);
+    }
+
+    #[test]
+    fn test_get_current_twice() {
+        let source = "ab";
+
+        let tape = Utf8Tape::new(&source);
+
+        assert_eq!(tape.get_current(), Some("a"));
+        assert_eq!(tape.get_current(), Some("a"));
+    }
+
+    #[test]
+    fn test_peak_next() {
+        let source = "ab";
+
+        let tape = Utf8Tape::new(&source);
+
+        assert_eq!(tape.peak_next(), Some("b"));
+    }
+
+    #[test]
+    fn test_peak_next_twice() {
+        let source = "ab";
+
+        let tape = Utf8Tape::new(&source);
+
+        assert_eq!(tape.peak_next(), Some("b"));
+        assert_eq!(tape.peak_next(), Some("b"));
+    }
+
+    #[test]
+    fn test_peak_next_for_empty() {
+        let source = "";
+
+        let tape = Utf8Tape::new(&source);
+
+        assert_eq!(tape.peak_next(), None);
+    }
+
+    #[test]
+    fn test_advance() {
+        let source = "ab";
+
+        let mut tape = Utf8Tape::new(&source);
+
+        tape.advance();
+        assert_eq!(tape.get_current(), Some("b"));
+        assert_eq!(tape.peak_next(), None);
+    }
+
+    #[test]
+    fn test_advance_for_empty() {
+        let source = "";
+
+        let mut tape = Utf8Tape::new(&source);
+
+        tape.advance();
+        assert_eq!(tape.get_current(), None);
+        assert_eq!(tape.peak_next(), None);
+    }
+}

--- a/src/core/engine/lexer/utf8_tape/mod.rs
+++ b/src/core/engine/lexer/utf8_tape/mod.rs
@@ -1,5 +1,6 @@
 use crate::util::Tape;
 
+/// A UTF-8 character tape from a string.
 pub struct Utf8Tape<'a> {
     chars: Vec<&'a str>,
     base_index: usize,

--- a/src/core/err/lex/mod.rs
+++ b/src/core/err/lex/mod.rs
@@ -1,0 +1,28 @@
+use crate::util::Range;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum LexErr<'a> {
+    IllegalChar(&'a str, Range),
+    BadNumLiteral(&'a str, Range),
+}
+
+impl<'a> fmt::Display for LexErr<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LexErr::IllegalChar(str, location) => write!(
+                f,
+                "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
+                str, location
+            ),
+            LexErr::BadNumLiteral(str, location) => write!(
+                f,
+                "Reason: LEX_BAD_NUM_LITERAL, Cause: '{}', Location: {:?}",
+                str, location
+            ),
+        }
+    }
+}
+
+impl<'a> Error for LexErr<'a> {}

--- a/src/core/err/lex/mod.rs
+++ b/src/core/err/lex/mod.rs
@@ -2,6 +2,8 @@ use crate::util::Range;
 use std::error::Error;
 use std::fmt;
 
+/// Errors that can occur during the lexing process.
+/// Serves as the interface between a lexer and its user.
 #[derive(Debug)]
 pub enum LexErr<'a> {
     IllegalChar(&'a str, Range),

--- a/src/core/err/mod.rs
+++ b/src/core/err/mod.rs
@@ -1,0 +1,3 @@
+mod lex;
+
+pub use lex::LexErr;

--- a/src/core/err/mod.rs
+++ b/src/core/err/mod.rs
@@ -1,3 +1,26 @@
 mod lex;
+use std::error::Error;
+use std::fmt;
 
 pub use lex::LexErr;
+
+#[derive(Debug)]
+pub enum ExecErr<'a> {
+    Lex(LexErr<'a>),
+}
+
+impl<'a> fmt::Display for ExecErr<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ExecErr::Lex(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl<'a> From<LexErr<'a>> for ExecErr<'a> {
+    fn from(err: LexErr<'a>) -> Self {
+        ExecErr::Lex(err)
+    }
+}
+
+impl<'a> Error for ExecErr<'a> {}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,8 +1,9 @@
 mod engine;
+mod err;
 mod syntax;
 
 pub fn execute(source: &str) -> String {
-    let tokens = engine::lex(&source);
+    let tokens = engine::lex(&source).unwrap();
     let ast = engine::parse(&tokens);
     let value = engine::evaluate(&ast);
     let representation = engine::represent(&value);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,7 +2,7 @@ mod engine;
 mod err;
 mod syntax;
 
-use err::ExecErr;
+pub use err::ExecErr;
 
 pub fn execute(source: &str) -> Result<String, ExecErr> {
     let tokens = engine::lex(&source)?;
@@ -25,6 +25,15 @@ mod tests {
         let executed = execute(source)?;
 
         assert_eq!(executed, "1");
+        Ok(())
+    }
+
+    #[test]
+    fn test_fail() -> Res {
+        let source = " ";
+        let executed = execute(source);
+
+        assert!(matches!(executed, Err(ExecErr::Lex(_))));
         Ok(())
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,13 +2,15 @@ mod engine;
 mod err;
 mod syntax;
 
-pub fn execute(source: &str) -> String {
-    let tokens = engine::lex(&source).unwrap();
+use err::ExecErr;
+
+pub fn execute(source: &str) -> Result<String, ExecErr> {
+    let tokens = engine::lex(&source)?;
     let ast = engine::parse(&tokens);
     let value = engine::evaluate(&ast);
     let representation = engine::represent(&value);
 
-    representation
+    Ok(representation)
 }
 
 #[cfg(test)]
@@ -16,10 +18,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn should_work() {
+    fn should_work() -> Result<(), ExecErr<'static>> {
         let source = "1";
-        let executed = execute(source);
+        let executed = execute(source)?;
 
         assert_eq!(executed, "1");
+        Ok(())
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,8 +17,10 @@ pub fn execute(source: &str) -> Result<String, ExecErr> {
 mod tests {
     use super::*;
 
+    type Res = Result<(), ExecErr<'static>>;
+
     #[test]
-    fn should_work() -> Result<(), ExecErr<'static>> {
+    fn should_work() -> Res {
         let source = "1";
         let executed = execute(source)?;
 

--- a/src/core/syntax/ast/mod.rs
+++ b/src/core/syntax/ast/mod.rs
@@ -1,10 +1,13 @@
 use crate::util::Range;
 
+/// Kinds of AST produced during parsing.
+/// Serves as the interface between a parser and its user.
 #[derive(Debug, PartialEq)]
 pub enum AstKind {
     Number(f64),
 }
 
+/// An abstract syntax tree, or AST produced during parsing.
 #[derive(Debug, PartialEq)]
 pub struct Ast {
     kind: AstKind,

--- a/src/core/syntax/token/mod.rs
+++ b/src/core/syntax/token/mod.rs
@@ -1,10 +1,13 @@
 use crate::util::Range;
 
+/// Kinds of tokens produced during lexing.
+/// Serves as the interface between a lexer and its user.
 #[derive(Debug, PartialEq)]
 pub enum TokenKind {
     Number(f64),
 }
 
+/// A token produced during lexing.
 #[derive(Debug, PartialEq)]
 pub struct Token {
     kind: TokenKind,

--- a/src/core/syntax/value/mod.rs
+++ b/src/core/syntax/value/mod.rs
@@ -1,10 +1,13 @@
 use crate::util::Range;
 
+/// Kinds of values produced during evaluation.
+/// Serves as the interface between an evaluator and its user.
 #[derive(Debug, PartialEq)]
 pub enum ValueKind {
     Number(f64),
 }
 
+/// A representation of the value produced during evaluation.
 #[derive(Debug, PartialEq)]
 pub struct Value {
     kind: ValueKind,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
 mod core;
 mod util;
 
+use util::exec_fmt;
+
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn execute(source: &str) -> String {
-    core::execute(source)
+    match core::execute(source) {
+        Ok(s) => exec_fmt::fmt_ok(&s),
+        Err(e) => exec_fmt::fmt_err(e),
+    }
 }
 
 #[cfg(test)]
@@ -17,6 +22,26 @@ mod tests {
         let source = "1";
         let executed = execute(source);
 
-        assert_eq!(executed, "1");
+        assert_eq!(executed, exec_fmt::fmt_ok("1"));
+    }
+
+    #[test]
+    fn test_execute_fail() {
+        let source = " ";
+        let executed = execute(source);
+
+        assert_err(&executed);
+    }
+
+    fn assert_err(executed: &str) -> () {
+        assert!(
+            is_err(&executed),
+            "Expected an error, but received '{}'",
+            executed
+        );
+    }
+
+    fn is_err(executed: &str) -> bool {
+        executed.starts_with("{ err: \"")
     }
 }

--- a/src/util/exec_fmt/mod.rs
+++ b/src/util/exec_fmt/mod.rs
@@ -1,0 +1,9 @@
+use crate::core::ExecErr;
+
+pub fn fmt_ok(s: &str) -> String {
+    format!("{{ ok: \"{s}\" }}")
+}
+
+pub fn fmt_err(e: ExecErr) -> String {
+    format!("{{ err: \"{e}\" }}")
+}

--- a/src/util/location/range/mod.rs
+++ b/src/util/location/range/mod.rs
@@ -1,5 +1,6 @@
 use super::spot::Spot;
 
+/// A range representing the span of multiple characters in a multi-line text.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Range {
     begin: Spot,

--- a/src/util/location/range/mod.rs
+++ b/src/util/location/range/mod.rs
@@ -12,6 +12,10 @@ impl Range {
     }
 }
 
+pub fn from_spot(spot: &Spot) -> Range {
+    Range::new(spot.clone(), spot.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/util/location/spot/mod.rs
+++ b/src/util/location/spot/mod.rs
@@ -1,3 +1,4 @@
+/// A position representing the coordinate of a character in multi-line text.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Spot {
     row: u64,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,8 @@
 pub mod location;
+pub mod string;
 pub mod tape;
 
+pub use location::range;
 pub use location::range::Range;
 pub use location::spot::Spot;
 pub use tape::Tape;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod exec_fmt;
 pub mod location;
 pub mod string;
 pub mod tape;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,6 @@
 pub mod location;
+pub mod tape;
 
 pub use location::range::Range;
 pub use location::spot::Spot;
+pub use tape::Tape;

--- a/src/util/string/mod.rs
+++ b/src/util/string/mod.rs
@@ -1,0 +1,7 @@
+pub fn is_ascii_single_digit(s: &str) -> bool {
+    s.len() == 1 && s.chars().next().unwrap().is_ascii_digit()
+}
+
+pub fn is_ascii_single_whitespace(s: &str) -> bool {
+    s.len() == 1 && s.chars().next().unwrap().is_ascii_whitespace()
+}

--- a/src/util/tape/mod.rs
+++ b/src/util/tape/mod.rs
@@ -1,0 +1,7 @@
+pub trait Tape {
+    type Item;
+
+    fn get_current(&self) -> Option<Self::Item>;
+    fn peak_next(&self) -> Option<Self::Item>;
+    fn advance(&mut self) -> ();
+}

--- a/src/util/tape/mod.rs
+++ b/src/util/tape/mod.rs
@@ -1,3 +1,4 @@
+/// A tape-like behaviour that reads items one by one, with the ability to peek at the next item without advancing.
 pub trait Tape {
     type Item;
 


### PR DESCRIPTION
error handling is important

feats:
- now lexer is real, but minimal (recognizes only numbers)
- error interface as string: gives `{ err: ... }` as an error, `{ ok: ... }` as a success

(internal) feats:
- `tape` trait: abstracts the 'reading current' and 'peeking at the next' behaviors
- on top of the `tape`, utf-8 tape gives the ability to recognize utf-8 character one by one
- on top of the utf-8 tape, source reader reads 'reading units' one by one
- note: here reading units are not a single character (e.g., CRLF `"\r\n"` is the reading unit)
- note: `tape` trait may be used later for a parser to read tokens one by one