### PR TITLE
abstract scanning into trait

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -3,4 +3,5 @@
 echo "Info: check formatting" && cargo fmt --check && \
   echo "Info: check rust errors" && cargo check --locked && \
   echo "Info: run unit test" && cargo test --locked && \
-  echo "Info: run integration test" && ./bin/test.sh
+  echo "Info: run integration test" && ./bin/test.sh && \
+  echo "Info: ci passed"

--- a/justfile
+++ b/justfile
@@ -6,3 +6,6 @@ clean:
 
 test:
   ./bin/test.sh
+
+ci:
+  ./bin/ci.sh

--- a/src/core/engine/evaluator/mod.rs
+++ b/src/core/engine/evaluator/mod.rs
@@ -1,6 +1,8 @@
 use crate::core::err::EvalErr;
 use crate::core::syntax::{Ast, AstKind, Value, ValueKind};
-use crate::util::{Range, Spot};
+use crate::util::Range;
+
+type ResVal = Result<Value, EvalErr>;
 
 struct Evaluator<'a> {
     ast: &'a Ast,
@@ -11,9 +13,12 @@ impl<'a> Evaluator<'a> {
         Self { ast }
     }
 
-    pub fn eval(&self) -> Result<Value, EvalErr> {
-        // TODO: reduce typing type
+    pub fn eval(&self) -> ResVal {
         match self.ast {
+            Ast {
+                kind: AstKind::Number(n),
+                location,
+            } => Self::eval_number(n, location),
             Ast {
                 kind: AstKind::Number(n),
                 location,
@@ -21,12 +26,12 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    fn eval_number(num: &f64, location: &Range) -> Result<Value, EvalErr> {
+    fn eval_number(num: &f64, location: &Range) -> ResVal {
         Ok(Value::new(ValueKind::Number(*num), *location))
     }
 }
 
-pub fn evaluate(ast: &Ast) -> Result<Value, EvalErr> {
+pub fn evaluate(ast: &Ast) -> ResVal {
     Evaluator::new(ast).eval()
 }
 
@@ -34,7 +39,9 @@ pub fn evaluate(ast: &Ast) -> Result<Value, EvalErr> {
 mod tests {
     use super::*;
     use crate::core::syntax::ValueKind;
-    use std::error::Error;
+    use crate::util::Spot;
+
+    type Res = Result<(), EvalErr>;
 
     const RANGE_MOCKS: &[Range] = &[
         Range::new(Spot::new(0, 0), Spot::new(1, 0)),
@@ -42,7 +49,7 @@ mod tests {
     ];
 
     #[test]
-    fn fake_evaluate() -> Result<(), Box<dyn Error>> {
+    fn fake_evaluate() -> Res {
         let ast = Ast::new(AstKind::Number(1.0), RANGE_MOCKS[0]);
 
         let value = evaluate(&ast)?;

--- a/src/core/engine/evaluator/mod.rs
+++ b/src/core/engine/evaluator/mod.rs
@@ -1,8 +1,8 @@
-use crate::core::err::EvalErr;
+use crate::core::err::EvalError;
 use crate::core::syntax::{Ast, AstKind, Value, ValueKind};
 use crate::util::Range;
 
-type ResVal = Result<Value, EvalErr>;
+type ResVal = Result<Value, EvalError>;
 
 struct Evaluator<'a> {
     ast: &'a Ast,
@@ -41,7 +41,7 @@ mod tests {
     use crate::core::syntax::ValueKind;
     use crate::util::Spot;
 
-    type Res = Result<(), EvalErr>;
+    type Res = Result<(), EvalError>;
 
     const RANGE_MOCKS: &[Range] = &[
         Range::new(Spot::new(0, 0), Spot::new(1, 0)),

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -1,14 +1,14 @@
 mod source_reader;
 mod utf8_tape;
 
-use crate::core::err::LexErr;
+use crate::core::err::LexError;
 use crate::core::syntax::{Token, TokenKind};
 use crate::util::string;
 use crate::util::{Range, range};
 use source_reader::SourceReader;
 
-type ResTokens = Result<Vec<Token>, LexErr>;
-type ResToken = Result<Token, LexErr>;
+type ResTokens = Result<Vec<Token>, LexError>;
+type ResToken = Result<Token, LexError>;
 
 /// A lexer to produce tokens from a source.
 struct Lexer<'a> {
@@ -29,7 +29,7 @@ impl<'a> Lexer<'a> {
             match self.reader.read() {
                 Some(s) if string::is_ascii_single_digit(s) => tokens.push(self.lex_num()?),
                 Some(x) => {
-                    return Err(LexErr::IllegalChar(
+                    return Err(LexError::IllegalChar(
                         x.to_string(),
                         range::from_spot(&self.reader.spot()),
                     ));
@@ -56,7 +56,7 @@ impl<'a> Lexer<'a> {
                 }
                 Some(s) if !string::is_ascii_single_whitespace(s) && s != "." => {
                     let end = self.reader.spot();
-                    return Err(LexErr::BadNumLiteral(s.to_string(), Range::new(begin, end)));
+                    return Err(LexError::BadNumLiteral(s.to_string(), Range::new(begin, end)));
                 }
                 _ => {
                     break;
@@ -84,7 +84,7 @@ impl<'a> Lexer<'a> {
                 }
                 Some(s) if !string::is_ascii_single_whitespace(s) => {
                     let end = self.reader.spot();
-                    return Err(LexErr::BadNumLiteral(s.to_string(), Range::new(begin, end)));
+                    return Err(LexError::BadNumLiteral(s.to_string(), Range::new(begin, end)));
                 }
                 _ => {
                     break;
@@ -110,7 +110,7 @@ mod tests {
     use super::*;
     use crate::util::Spot;
 
-    type Res = Result<(), LexErr>;
+    type Res = Result<(), LexError>;
 
     #[test]
     fn lex_num_int() -> Res {
@@ -146,7 +146,7 @@ mod tests {
 
         let token = Lexer::new(source).lex();
 
-        assert!(matches!(token, Err(LexErr::BadNumLiteral(_, _))));
+        assert!(matches!(token, Err(LexError::BadNumLiteral(_, _))));
         Ok(())
     }
 
@@ -156,7 +156,7 @@ mod tests {
 
         let token = Lexer::new(source).lex();
 
-        assert!(matches!(token, Err(LexErr::IllegalChar(_, _))));
+        assert!(matches!(token, Err(LexError::IllegalChar(_, _))));
         Ok(())
     }
 }

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -1,24 +1,24 @@
-mod source_reader;
+mod source_scanner;
 mod utf8_tape;
 
 use crate::core::err::LexError;
 use crate::core::syntax::{Token, TokenKind};
 use crate::util::string;
 use crate::util::{Range, Scanner};
-use source_reader::SourceReader;
+use source_scanner::SourceScanner;
 
 type ResTokens = Result<Vec<Token>, LexError>;
 type ResToken = Result<Token, LexError>;
 
 /// A lexer to produce tokens from a source.
 struct Lexer<'a> {
-    reader: SourceReader<'a>,
+    reader: SourceScanner<'a>,
 }
 
 impl<'a> Lexer<'a> {
     pub fn new(source: &'a str) -> Self {
         Self {
-            reader: SourceReader::new(source),
+            reader: SourceScanner::new(source),
         }
     }
 

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -4,8 +4,11 @@ mod utf8_tape;
 use crate::core::err::LexErr;
 use crate::core::syntax::{Token, TokenKind};
 use crate::util::string;
-use crate::util::{Range, Spot, range};
+use crate::util::{Range, range};
 use source_reader::SourceReader;
+
+type ResTokens = Result<Vec<Token>, LexErr>;
+type ResToken = Result<Token, LexErr>;
 
 /// A lexer to produce tokens from a source.
 struct Lexer<'a> {
@@ -19,7 +22,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    pub fn lex(&mut self) -> Result<Vec<Token>, LexErr> {
+    pub fn lex(&mut self) -> ResTokens {
         let mut tokens: Vec<Token> = vec![];
 
         loop {
@@ -40,7 +43,7 @@ impl<'a> Lexer<'a> {
         Ok(tokens)
     }
 
-    fn lex_num(&mut self) -> Result<Token, LexErr> {
+    fn lex_num(&mut self) -> ResToken {
         let mut lexeme = String::new();
         let begin = self.reader.spot();
 
@@ -97,7 +100,7 @@ impl<'a> Lexer<'a> {
     }
 }
 
-pub fn lex(source: &str) -> Result<Vec<Token>, LexErr> {
+pub fn lex(source: &str) -> ResTokens {
     let tokens = Lexer::new(source).lex()?;
     Ok(tokens)
 }
@@ -105,10 +108,12 @@ pub fn lex(source: &str) -> Result<Vec<Token>, LexErr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error::Error;
+    use crate::util::Spot;
+
+    type Res = Result<(), LexErr>;
 
     #[test]
-    fn lex_num_int() -> Result<(), Box<dyn Error>> {
+    fn lex_num_int() -> Res {
         let source = "123";
 
         let token = Lexer::new(source).lex()?;
@@ -122,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn lex_num_float() -> Result<(), Box<dyn Error>> {
+    fn lex_num_float() -> Res {
         let source = "12.25"; // chosen to be equal on float comparison
 
         let token = Lexer::new(source).lex()?;
@@ -136,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn lex_num_fail() -> Result<(), Box<dyn Error>> {
+    fn lex_num_fail() -> Res {
         let source = "12a";
 
         let token = Lexer::new(source).lex();
@@ -146,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn lex_fail() -> Result<(), Box<dyn Error>> {
+    fn lex_fail() -> Res {
         let source = " ";
 
         let token = Lexer::new(source).lex();

--- a/src/core/engine/lexer/source_reader/mod.rs
+++ b/src/core/engine/lexer/source_reader/mod.rs
@@ -140,54 +140,87 @@ mod tests {
     }
 
     #[test]
-    fn test_spot_col() {
+    fn test_locate_col_changes() {
         let source = "ab";
         let mut reader = SourceReader::new(source);
 
         assert_eq!(reader.read(), Some("a"));
-        assert_eq!(reader.spot(), Spot::new(0, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(0, 0), Spot::new(0, 1))
+        );
         reader.advance();
         assert_eq!(reader.read(), Some("b"));
-        assert_eq!(reader.spot(), Spot::new(0, 1));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(0, 1), Spot::new(0, 2))
+        );
         reader.advance();
         assert_eq!(reader.read(), None);
-        assert_eq!(reader.spot(), Spot::new(0, 2));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(0, 2), Spot::new(0, 3))
+        );
         reader.advance();
         assert_eq!(reader.read(), None);
-        assert_eq!(reader.spot(), Spot::new(0, 2));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(0, 2), Spot::new(0, 3))
+        );
     }
 
     #[test]
-    fn test_spot_row() {
+    fn test_locate_row_changes() {
         let source = "\r\n\n\r";
         let mut reader = SourceReader::new(source);
 
         assert_eq!(reader.read(), Some("\r\n"));
-        assert_eq!(reader.spot(), Spot::new(0, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(0, 0), Spot::new(0, 1))
+        );
         reader.advance();
         assert_eq!(reader.read(), Some("\n"));
-        assert_eq!(reader.spot(), Spot::new(1, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(1, 0), Spot::new(1, 1))
+        );
         reader.advance();
         assert_eq!(reader.read(), Some("\r"));
-        assert_eq!(reader.spot(), Spot::new(2, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(2, 0), Spot::new(2, 1))
+        );
         reader.advance();
         assert_eq!(reader.read(), None);
-        assert_eq!(reader.spot(), Spot::new(3, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(3, 0), Spot::new(3, 1))
+        );
         reader.advance();
         assert_eq!(reader.read(), None);
-        assert_eq!(reader.spot(), Spot::new(3, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(3, 0), Spot::new(3, 1))
+        );
     }
 
     #[test]
-    fn test_spot_col_reset() {
+    fn test_locate_col_reset() {
         let source = "a\r\nb";
         let mut reader = SourceReader::new(source);
 
         reader.advance();
         assert_eq!(reader.read(), Some("\r\n"));
-        assert_eq!(reader.spot(), Spot::new(0, 1));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(0, 1), Spot::new(0, 2))
+        );
         reader.advance();
         assert_eq!(reader.read(), Some("b"));
-        assert_eq!(reader.spot(), Spot::new(1, 0));
+        assert_eq!(
+            reader.locate(),
+            Range::new(Spot::new(1, 0), Spot::new(1, 1))
+        );
     }
 }

--- a/src/core/engine/lexer/source_reader/mod.rs
+++ b/src/core/engine/lexer/source_reader/mod.rs
@@ -1,5 +1,5 @@
 use super::utf8_tape::Utf8Tape;
-use crate::util::{Spot, Tape, Range};
+use crate::util::{Range, Scanner, Spot, Tape};
 
 /// A character reader from a source.
 /// It reads characters one by one, but treats CRLF ("\r\n") as a single character.
@@ -17,8 +17,12 @@ impl<'a> SourceReader<'a> {
             row: 0,
         }
     }
+}
 
-    pub fn read(&self) -> Option<&'a str> {
+impl<'a> Scanner for SourceReader<'a> {
+    type Item = &'a str;
+
+    fn read(&self) -> Option<&'a str> {
         match self.tape.get_current() {
             Some("\r") => match self.tape.peek_next() {
                 Some("\n") => Some("\r\n"),
@@ -28,7 +32,7 @@ impl<'a> SourceReader<'a> {
         }
     }
 
-    pub fn advance(&mut self) -> () {
+    fn advance(&mut self) -> () {
         match self.read() {
             Some("\r") | Some("\n") => {
                 self.row += 1;
@@ -49,13 +53,11 @@ impl<'a> SourceReader<'a> {
         }
     }
 
-    #[deprecated]
-    pub fn spot(&self) -> Spot {
-        Spot::new(self.row, self.col)
-    }
-
-    pub fn locate(&self) -> Range {
-        Range::from_spot(&Spot::new(self.row, self.col))
+    fn locate(&self) -> Range {
+        Range::new(
+            Spot::new(self.row, self.col),
+            Spot::new(self.row, self.col + 1),
+        )
     }
 }
 

--- a/src/core/engine/lexer/source_reader/mod.rs
+++ b/src/core/engine/lexer/source_reader/mod.rs
@@ -1,5 +1,5 @@
 use super::utf8_tape::Utf8Tape;
-use crate::util::{Spot, Tape};
+use crate::util::{Spot, Tape, Range};
 
 /// A character reader from a source.
 /// It reads characters one by one, but treats CRLF ("\r\n") as a single character.
@@ -49,8 +49,13 @@ impl<'a> SourceReader<'a> {
         }
     }
 
+    #[deprecated]
     pub fn spot(&self) -> Spot {
         Spot::new(self.row, self.col)
+    }
+
+    pub fn locate(&self) -> Range {
+        Range::from_spot(&Spot::new(self.row, self.col))
     }
 }
 

--- a/src/core/engine/lexer/source_scanner/mod.rs
+++ b/src/core/engine/lexer/source_scanner/mod.rs
@@ -3,13 +3,13 @@ use crate::util::{Range, Scanner, Spot, Tape};
 
 /// A character reader from a source.
 /// It reads characters one by one, but treats CRLF ("\r\n") as a single character.
-pub struct SourceReader<'a> {
+pub struct SourceScanner<'a> {
     tape: Utf8Tape<'a>,
     col: u64,
     row: u64,
 }
 
-impl<'a> SourceReader<'a> {
+impl<'a> SourceScanner<'a> {
     pub fn new(source: &'a str) -> Self {
         Self {
             tape: Utf8Tape::new(source),
@@ -19,7 +19,7 @@ impl<'a> SourceReader<'a> {
     }
 }
 
-impl<'a> Scanner for SourceReader<'a> {
+impl<'a> Scanner for SourceScanner<'a> {
     type Item = &'a str;
 
     fn read(&self) -> Option<&'a str> {
@@ -68,7 +68,7 @@ mod tests {
     #[test]
     fn test_read() {
         let source = "ab";
-        let reader = SourceReader::new(source);
+        let reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("a"));
     }
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_read_twice() {
         let source = "ab";
-        let reader = SourceReader::new(source);
+        let reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("a"));
         assert_eq!(reader.read(), Some("a"));
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn test_read_empty() {
         let source = "";
-        let reader = SourceReader::new(source);
+        let reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), None);
     }
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn test_advance() {
         let source = "ab";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         reader.advance();
         assert_eq!(reader.read(), Some("b"));
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn test_read_lf() {
         let source = "\n\n";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("\n"));
         assert_eq!(reader.read(), Some("\n"));
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn test_read_cr() {
         let source = "\r\r";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("\r"));
         assert_eq!(reader.read(), Some("\r"));
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn test_read_crlf() {
         let source = "\r\n\r\n";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("\r\n"));
         assert_eq!(reader.read(), Some("\r\n"));
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn test_locate_col_changes() {
         let source = "ab";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("a"));
         assert_eq!(
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn test_locate_row_changes() {
         let source = "\r\n\n\r";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         assert_eq!(reader.read(), Some("\r\n"));
         assert_eq!(
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn test_locate_col_reset() {
         let source = "a\r\nb";
-        let mut reader = SourceReader::new(source);
+        let mut reader = SourceScanner::new(source);
 
         reader.advance();
         assert_eq!(reader.read(), Some("\r\n"));

--- a/src/core/engine/lexer/source_scanner/mod.rs
+++ b/src/core/engine/lexer/source_scanner/mod.rs
@@ -1,7 +1,7 @@
 use super::utf8_tape::Utf8Tape;
 use crate::util::{Range, Scanner, Spot, Tape};
 
-/// A character reader from a source.
+/// A character scaner from a source.
 /// It reads characters one by one, but treats CRLF ("\r\n") as a single character.
 pub struct SourceScanner<'a> {
     tape: Utf8Tape<'a>,
@@ -68,105 +68,105 @@ mod tests {
     #[test]
     fn test_read() {
         let source = "ab";
-        let reader = SourceScanner::new(source);
+        let scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("a"));
+        assert_eq!(scanner.read(), Some("a"));
     }
 
     #[test]
     fn test_read_twice() {
         let source = "ab";
-        let reader = SourceScanner::new(source);
+        let scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("a"));
-        assert_eq!(reader.read(), Some("a"));
+        assert_eq!(scanner.read(), Some("a"));
+        assert_eq!(scanner.read(), Some("a"));
     }
 
     #[test]
     fn test_read_empty() {
         let source = "";
-        let reader = SourceScanner::new(source);
+        let scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), None);
+        assert_eq!(scanner.read(), None);
     }
 
     #[test]
     fn test_advance() {
         let source = "ab";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        reader.advance();
-        assert_eq!(reader.read(), Some("b"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("b"));
     }
 
     #[test]
     fn test_read_lf() {
         let source = "\n\n";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("\n"));
-        assert_eq!(reader.read(), Some("\n"));
-        reader.advance();
-        assert_eq!(reader.read(), Some("\n"));
-        assert_eq!(reader.read(), Some("\n"));
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        assert_eq!(scanner.read(), Some("\n"));
+        assert_eq!(scanner.read(), Some("\n"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("\n"));
+        assert_eq!(scanner.read(), Some("\n"));
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
     }
 
     #[test]
     fn test_read_cr() {
         let source = "\r\r";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("\r"));
-        assert_eq!(reader.read(), Some("\r"));
-        reader.advance();
-        assert_eq!(reader.read(), Some("\r"));
-        assert_eq!(reader.read(), Some("\r"));
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        assert_eq!(scanner.read(), Some("\r"));
+        assert_eq!(scanner.read(), Some("\r"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("\r"));
+        assert_eq!(scanner.read(), Some("\r"));
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
     }
 
     #[test]
     fn test_read_crlf() {
         let source = "\r\n\r\n";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("\r\n"));
-        assert_eq!(reader.read(), Some("\r\n"));
-        reader.advance();
-        assert_eq!(reader.read(), Some("\r\n"));
-        assert_eq!(reader.read(), Some("\r\n"));
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        assert_eq!(scanner.read(), Some("\r\n"));
+        assert_eq!(scanner.read(), Some("\r\n"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("\r\n"));
+        assert_eq!(scanner.read(), Some("\r\n"));
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
     }
 
     #[test]
     fn test_locate_col_changes() {
         let source = "ab";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("a"));
+        assert_eq!(scanner.read(), Some("a"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(0, 0), Spot::new(0, 1))
         );
-        reader.advance();
-        assert_eq!(reader.read(), Some("b"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("b"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(0, 1), Spot::new(0, 2))
         );
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(0, 2), Spot::new(0, 3))
         );
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(0, 2), Spot::new(0, 3))
         );
     }
@@ -174,35 +174,35 @@ mod tests {
     #[test]
     fn test_locate_row_changes() {
         let source = "\r\n\n\r";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        assert_eq!(reader.read(), Some("\r\n"));
+        assert_eq!(scanner.read(), Some("\r\n"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(0, 0), Spot::new(0, 1))
         );
-        reader.advance();
-        assert_eq!(reader.read(), Some("\n"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("\n"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(1, 0), Spot::new(1, 1))
         );
-        reader.advance();
-        assert_eq!(reader.read(), Some("\r"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("\r"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(2, 0), Spot::new(2, 1))
         );
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(3, 0), Spot::new(3, 1))
         );
-        reader.advance();
-        assert_eq!(reader.read(), None);
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(3, 0), Spot::new(3, 1))
         );
     }
@@ -210,18 +210,18 @@ mod tests {
     #[test]
     fn test_locate_col_reset() {
         let source = "a\r\nb";
-        let mut reader = SourceScanner::new(source);
+        let mut scanner = SourceScanner::new(source);
 
-        reader.advance();
-        assert_eq!(reader.read(), Some("\r\n"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("\r\n"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(0, 1), Spot::new(0, 2))
         );
-        reader.advance();
-        assert_eq!(reader.read(), Some("b"));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some("b"));
         assert_eq!(
-            reader.locate(),
+            scanner.locate(),
             Range::new(Spot::new(1, 0), Spot::new(1, 1))
         );
     }

--- a/src/core/engine/parser/mod.rs
+++ b/src/core/engine/parser/mod.rs
@@ -2,7 +2,7 @@ mod token_scanner;
 
 use crate::core::err::ParseError;
 use crate::core::syntax::{Ast, AstKind, Token, TokenKind};
-use crate::util::{Range, Spot, Scanner};
+use crate::util::{Range, Scanner, Spot};
 use token_scanner::TokenScanner;
 
 type ResAst = Result<Ast, ParseError>;

--- a/src/core/engine/parser/mod.rs
+++ b/src/core/engine/parser/mod.rs
@@ -1,20 +1,20 @@
-mod token_tape;
+mod token_scanner;
 
 use crate::core::err::ParseError;
 use crate::core::syntax::{Ast, AstKind, Token, TokenKind};
 use crate::util::{Range, Spot, Scanner};
-use token_tape::TokenTape;
+use token_scanner::TokenScanner;
 
 type ResAst = Result<Ast, ParseError>;
 
 struct Parser<'a> {
-    token_tape: TokenTape<'a>,
+    scanner: TokenScanner<'a>,
 }
 
 impl<'a> Parser<'a> {
     pub fn new(tokens: &'a Vec<Token>) -> Self {
         Self {
-            token_tape: TokenTape::new(tokens),
+            scanner: TokenScanner::new(tokens),
         }
     }
 
@@ -27,7 +27,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_num(&self) -> ResAst {
-        match self.token_tape.read() {
+        match self.scanner.read() {
             Some(Token {
                 kind: TokenKind::Number(n),
                 location,

--- a/src/core/engine/parser/mod.rs
+++ b/src/core/engine/parser/mod.rs
@@ -1,11 +1,11 @@
 mod token_tape;
 
-use crate::core::err::ParseErr;
+use crate::core::err::ParseError;
 use crate::core::syntax::{Ast, AstKind, Token, TokenKind};
 use crate::util::{Range, Spot, Tape};
 use token_tape::TokenTape;
 
-type ResAst = Result<Ast, ParseErr>;
+type ResAst = Result<Ast, ParseError>;
 
 struct Parser<'a> {
     token_tape: TokenTape<'a>,
@@ -32,7 +32,7 @@ impl<'a> Parser<'a> {
                 kind: TokenKind::Number(n),
                 location,
             }) => Ok(Ast::new(AstKind::Number(*n), *location)),
-            _ => Err(ParseErr::Unexpected(
+            _ => Err(ParseError::Unexpected(
                 "Unexpected".to_string(),
                 Range::new(Spot::new(0, 0), Spot::new(0, 0)),
             )),
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
     use crate::core::syntax::AstKind;
 
-    type Res = Result<(), ParseErr>;
+    type Res = Result<(), ParseError>;
 
     const RANGE_MOCKS: &[Range] = &[
         Range::new(Spot::new(0, 0), Spot::new(1, 0)),

--- a/src/core/engine/parser/mod.rs
+++ b/src/core/engine/parser/mod.rs
@@ -2,7 +2,7 @@ mod token_tape;
 
 use crate::core::err::ParseError;
 use crate::core::syntax::{Ast, AstKind, Token, TokenKind};
-use crate::util::{Range, Spot, Tape};
+use crate::util::{Range, Spot, Scanner};
 use token_tape::TokenTape;
 
 type ResAst = Result<Ast, ParseError>;
@@ -27,7 +27,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_num(&self) -> ResAst {
-        match self.token_tape.get_current() {
+        match self.token_tape.read() {
             Some(Token {
                 kind: TokenKind::Number(n),
                 location,

--- a/src/core/engine/parser/mod.rs
+++ b/src/core/engine/parser/mod.rs
@@ -5,6 +5,8 @@ use crate::core::syntax::{Ast, AstKind, Token, TokenKind};
 use crate::util::{Range, Spot, Tape};
 use token_tape::TokenTape;
 
+type ResAst = Result<Ast, ParseErr>;
+
 struct Parser<'a> {
     token_tape: TokenTape<'a>,
 }
@@ -16,15 +18,15 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse(&self) -> Result<Ast, ParseErr> {
+    pub fn parse(&self) -> ResAst {
         self.parse_program()
     }
 
-    fn parse_program(&self) -> Result<Ast, ParseErr> {
+    fn parse_program(&self) -> ResAst {
         self.parse_num()
     }
 
-    fn parse_num(&self) -> Result<Ast, ParseErr> {
+    fn parse_num(&self) -> ResAst {
         match self.token_tape.get_current() {
             Some(Token {
                 kind: TokenKind::Number(n),
@@ -38,7 +40,7 @@ impl<'a> Parser<'a> {
     }
 }
 
-pub fn parse(tokens: &Vec<Token>) -> Result<Ast, ParseErr> {
+pub fn parse(tokens: &Vec<Token>) -> ResAst {
     Parser::new(tokens).parse()
 }
 
@@ -47,7 +49,7 @@ mod tests {
     use super::*;
     use crate::core::syntax::AstKind;
 
-    use std::error::Error;
+    type Res = Result<(), ParseErr>;
 
     const RANGE_MOCKS: &[Range] = &[
         Range::new(Spot::new(0, 0), Spot::new(1, 0)),
@@ -60,7 +62,7 @@ mod tests {
     ];
 
     #[test]
-    fn parse_num() -> Result<(), Box<dyn Error>> {
+    fn parse_num() -> Res {
         let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
 
         let ast = parse(&tokens)?;

--- a/src/core/engine/parser/token_scanner/mod.rs
+++ b/src/core/engine/parser/token_scanner/mod.rs
@@ -1,13 +1,13 @@
 use crate::core::syntax::Token;
 use crate::util::{Range, Scanner, range};
 
-pub struct TokenTape<'a> {
+pub struct TokenScanner<'a> {
     tokens: &'a Vec<Token>,
     base_index: usize,
     last_location: Range,
 }
 
-impl<'a> TokenTape<'a> {
+impl<'a> TokenScanner<'a> {
     pub fn new(tokens: &'a Vec<Token>) -> Self {
         Self {
             tokens,
@@ -17,7 +17,7 @@ impl<'a> TokenTape<'a> {
     }
 }
 
-impl<'a> Scanner for TokenTape<'a> {
+impl<'a> Scanner for TokenScanner<'a> {
     type Item = &'a Token;
 
     fn read(&self) -> Option<Self::Item> {
@@ -60,38 +60,38 @@ mod tests {
     fn test_read_for_empty() {
         let tokens: Vec<Token> = vec![];
 
-        let tape = TokenTape::new(&tokens);
+        let scanner = TokenScanner::new(&tokens);
 
-        assert_eq!(tape.read(), None);
+        assert_eq!(scanner.read(), None);
     }
 
     #[test]
     fn test_read_twice() {
         let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
 
-        let tape = TokenTape::new(&tokens);
+        let scanner = TokenScanner::new(&tokens);
 
-        assert_eq!(tape.read(), Some(&TOKEN_MOCKS[0]));
-        assert_eq!(tape.read(), Some(&TOKEN_MOCKS[0]));
+        assert_eq!(scanner.read(), Some(&TOKEN_MOCKS[0]));
+        assert_eq!(scanner.read(), Some(&TOKEN_MOCKS[0]));
     }
 
     #[test]
     fn test_advance() {
         let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
 
-        let mut tape = TokenTape::new(&tokens);
+        let mut scanner = TokenScanner::new(&tokens);
 
-        tape.advance();
-        assert_eq!(tape.read(), Some(&TOKEN_MOCKS[1]));
+        scanner.advance();
+        assert_eq!(scanner.read(), Some(&TOKEN_MOCKS[1]));
     }
 
     #[test]
     fn test_advance_for_empty() {
         let tokens: Vec<Token> = vec![];
 
-        let mut tape = TokenTape::new(&tokens);
+        let mut scanner = TokenScanner::new(&tokens);
 
-        tape.advance();
-        assert_eq!(tape.read(), None);
+        scanner.advance();
+        assert_eq!(scanner.read(), None);
     }
 }

--- a/src/core/engine/parser/token_scanner/mod.rs
+++ b/src/core/engine/parser/token_scanner/mod.rs
@@ -94,4 +94,15 @@ mod tests {
         scanner.advance();
         assert_eq!(scanner.read(), None);
     }
+
+    #[test]
+    fn test_locate() {
+        let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
+
+        let mut scanner = TokenScanner::new(&tokens);
+
+        assert_eq!(scanner.locate(), RANGE_MOCKS[0]);
+        scanner.advance();
+        assert_eq!(scanner.locate(), RANGE_MOCKS[1]);
+    }
 }

--- a/src/core/engine/parser/token_tape/mod.rs
+++ b/src/core/engine/parser/token_tape/mod.rs
@@ -1,5 +1,5 @@
 use crate::core::syntax::Token;
-use crate::util::{Range, Scanner, Tape, range, tape};
+use crate::util::{Range, Scanner, range};
 
 pub struct TokenTape<'a> {
     tokens: &'a Vec<Token>,
@@ -40,26 +40,6 @@ impl<'a> Scanner for TokenTape<'a> {
     }
 }
 
-impl<'a> Tape for TokenTape<'a> {
-    type Item = &'a Token;
-
-    fn get_current(&self) -> Option<Self::Item> {
-        self.tokens.get(self.base_index)
-    }
-
-    fn peek_next(&self) -> Option<Self::Item> {
-        self.tokens.get(self.base_index + 1)
-    }
-
-    fn advance(&mut self) -> () {
-        if self.base_index == self.tokens.len() {
-            return ();
-        }
-
-        self.base_index += 1;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,50 +57,22 @@ mod tests {
     ];
 
     #[test]
-    fn test_get_current_for_empty() {
+    fn test_read_for_empty() {
         let tokens: Vec<Token> = vec![];
 
         let tape = TokenTape::new(&tokens);
 
-        assert_eq!(tape.get_current(), None);
+        assert_eq!(tape.read(), None);
     }
 
     #[test]
-    fn test_get_current_twice() {
+    fn test_read_twice() {
         let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
 
         let tape = TokenTape::new(&tokens);
 
-        assert_eq!(tape.get_current(), Some(&TOKEN_MOCKS[0]));
-        assert_eq!(tape.get_current(), Some(&TOKEN_MOCKS[0]));
-    }
-
-    #[test]
-    fn test_peek_next() {
-        let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
-
-        let tape = TokenTape::new(&tokens);
-
-        assert_eq!(tape.peek_next(), Some(&TOKEN_MOCKS[1]));
-    }
-
-    #[test]
-    fn test_peek_next_twice() {
-        let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
-
-        let tape = TokenTape::new(&tokens);
-
-        assert_eq!(tape.peek_next(), Some(&TOKEN_MOCKS[1]));
-        assert_eq!(tape.peek_next(), Some(&TOKEN_MOCKS[1]));
-    }
-
-    #[test]
-    fn test_peek_next_for_empty() {
-        let tokens: Vec<Token> = vec![];
-
-        let tape = TokenTape::new(&tokens);
-
-        assert_eq!(tape.get_current(), None);
+        assert_eq!(tape.read(), Some(&TOKEN_MOCKS[0]));
+        assert_eq!(tape.read(), Some(&TOKEN_MOCKS[0]));
     }
 
     #[test]
@@ -129,9 +81,8 @@ mod tests {
 
         let mut tape = TokenTape::new(&tokens);
 
-        tape::Tape::advance(&mut tape);
-        assert_eq!(tape.get_current(), Some(&TOKEN_MOCKS[1]));
-        assert_eq!(tape.peek_next(), None);
+        tape.advance();
+        assert_eq!(tape.read(), Some(&TOKEN_MOCKS[1]));
     }
 
     #[test]
@@ -140,8 +91,7 @@ mod tests {
 
         let mut tape = TokenTape::new(&tokens);
 
-        tape::Tape::advance(&mut tape);
-        assert_eq!(tape.get_current(), None);
-        assert_eq!(tape.peek_next(), None);
+        tape.advance();
+        assert_eq!(tape.read(), None);
     }
 }

--- a/src/core/err/eval/mod.rs
+++ b/src/core/err/eval/mod.rs
@@ -5,14 +5,14 @@ use std::fmt;
 /// Errors that can occur during the evaluating process.
 /// Serves as the interface between a evaluator and its user.
 #[derive(Debug)]
-pub enum EvalErr {
+pub enum EvalError {
     Unexpected(String, Range),
 }
 
-impl<'a> fmt::Display for EvalErr {
+impl<'a> fmt::Display for EvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            EvalErr::Unexpected(str, location) => write!(
+            EvalError::Unexpected(str, location) => write!(
                 f,
                 "Reason: PARSE_UNEXPECTED, Cause: '{}', Location: {:?}",
                 str, location
@@ -21,4 +21,4 @@ impl<'a> fmt::Display for EvalErr {
     }
 }
 
-impl<'a> Error for EvalErr {}
+impl<'a> Error for EvalError {}

--- a/src/core/err/lex/mod.rs
+++ b/src/core/err/lex/mod.rs
@@ -5,20 +5,20 @@ use std::fmt;
 /// Errors that can occur during the lexing process.
 /// Serves as the interface between a lexer and its user.
 #[derive(Debug)]
-pub enum LexErr {
+pub enum LexError {
     IllegalChar(String, Range),
     BadNumLiteral(String, Range),
 }
 
-impl fmt::Display for LexErr {
+impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            LexErr::IllegalChar(str, location) => write!(
+            LexError::IllegalChar(str, location) => write!(
                 f,
                 "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
                 str, location
             ),
-            LexErr::BadNumLiteral(str, location) => write!(
+            LexError::BadNumLiteral(str, location) => write!(
                 f,
                 "Reason: LEX_BAD_NUM_LITERAL, Cause: '{}', Location: {:?}",
                 str, location
@@ -27,4 +27,4 @@ impl fmt::Display for LexErr {
     }
 }
 
-impl<'a> Error for LexErr {}
+impl<'a> Error for LexError {}

--- a/src/core/err/mod.rs
+++ b/src/core/err/mod.rs
@@ -2,45 +2,45 @@ mod eval;
 mod lex;
 mod parse;
 
-pub use eval::EvalErr;
-pub use lex::LexErr;
-pub use parse::ParseErr;
+pub use eval::EvalError;
+pub use lex::LexError;
+pub use parse::ParseError;
 use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
-pub enum ExecErr {
-    LexErr(LexErr),
-    ParseErr(ParseErr),
-    EvalErr(EvalErr),
+pub enum ExecError {
+    LexError(LexError),
+    ParseError(ParseError),
+    EvalError(EvalError),
 }
 
-impl<'a> fmt::Display for ExecErr {
+impl<'a> fmt::Display for ExecError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ExecErr::LexErr(err) => err.fmt(f),
-            ExecErr::ParseErr(err) => err.fmt(f),
-            ExecErr::EvalErr(err) => err.fmt(f),
+            ExecError::LexError(err) => err.fmt(f),
+            ExecError::ParseError(err) => err.fmt(f),
+            ExecError::EvalError(err) => err.fmt(f),
         }
     }
 }
 
-impl From<LexErr> for ExecErr {
-    fn from(err: LexErr) -> Self {
-        ExecErr::LexErr(err)
+impl From<LexError> for ExecError {
+    fn from(err: LexError) -> Self {
+        ExecError::LexError(err)
     }
 }
 
-impl From<ParseErr> for ExecErr {
-    fn from(err: ParseErr) -> Self {
-        ExecErr::ParseErr(err)
+impl From<ParseError> for ExecError {
+    fn from(err: ParseError) -> Self {
+        ExecError::ParseError(err)
     }
 }
 
-impl From<EvalErr> for ExecErr {
-    fn from(err: EvalErr) -> Self {
-        ExecErr::EvalErr(err)
+impl From<EvalError> for ExecError {
+    fn from(err: EvalError) -> Self {
+        ExecError::EvalError(err)
     }
 }
 
-impl<'a> Error for ExecErr {}
+impl<'a> Error for ExecError {}

--- a/src/core/err/parse/mod.rs
+++ b/src/core/err/parse/mod.rs
@@ -5,14 +5,14 @@ use std::fmt;
 /// Errors that can occur during the parsing process.
 /// Serves as the interface between a parser and its user.
 #[derive(Debug)]
-pub enum ParseErr {
+pub enum ParseError {
     Unexpected(String, Range),
 }
 
-impl<'a> fmt::Display for ParseErr {
+impl<'a> fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseErr::Unexpected(str, location) => write!(
+            ParseError::Unexpected(str, location) => write!(
                 f,
                 "Reason: PARSE_UNEXPECTED, Cause: '{}', Location: {:?}",
                 str, location
@@ -21,4 +21,4 @@ impl<'a> fmt::Display for ParseErr {
     }
 }
 
-impl<'a> Error for ParseErr {}
+impl<'a> Error for ParseError {}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,9 +2,9 @@ mod engine;
 mod err;
 mod syntax;
 
-pub use err::ExecErr;
+pub use err::ExecError;
 
-pub fn execute(source: &str) -> Result<String, ExecErr> {
+pub fn execute(source: &str) -> Result<String, ExecError> {
     let tokens = engine::lex(&source)?;
     let ast = engine::parse(&tokens)?;
     let value = engine::evaluate(&ast)?;
@@ -17,7 +17,7 @@ pub fn execute(source: &str) -> Result<String, ExecErr> {
 mod tests {
     use super::*;
 
-    type Res = Result<(), ExecErr>;
+    type Res = Result<(), ExecError>;
 
     #[test]
     fn should_work() -> Res {
@@ -33,7 +33,7 @@ mod tests {
         let source = " ";
         let executed = execute(source);
 
-        assert!(matches!(executed, Err(ExecErr::LexErr(_))));
+        assert!(matches!(executed, Err(ExecError::LexError(_))));
         Ok(())
     }
 }

--- a/src/util/exec_fmt/mod.rs
+++ b/src/util/exec_fmt/mod.rs
@@ -1,9 +1,9 @@
-use crate::core::ExecErr;
+use crate::core::ExecError;
 
 pub fn fmt_ok(s: &str) -> String {
     format!("{{ \"ok\": \"{s}\" }}")
 }
 
-pub fn fmt_err(e: ExecErr) -> String {
+pub fn fmt_err(e: ExecError) -> String {
     format!("{{ \"err\": \"{e}\" }}")
 }

--- a/src/util/location/range/mod.rs
+++ b/src/util/location/range/mod.rs
@@ -1,3 +1,4 @@
+use super::spot;
 use super::spot::Spot;
 
 /// A range representing the span of multiple characters in a multi-line text.
@@ -12,6 +13,8 @@ impl Range {
         Range { begin, end }
     }
 }
+
+pub const ORIGIN: Range = Range::new(spot::ORIGIN, spot::ORIGIN);
 
 #[cfg(test)]
 mod tests {

--- a/src/util/location/range/mod.rs
+++ b/src/util/location/range/mod.rs
@@ -11,8 +11,13 @@ impl Range {
     pub const fn new(begin: Spot, end: Spot) -> Self {
         Range { begin, end }
     }
+
+    pub const fn from_spot(spot: &Spot) -> Self {
+        Range { begin: *spot, end: *spot }
+    }
 }
 
+#[deprecated]
 pub const fn from_spot(spot: &Spot) -> Range {
     Range::new(*spot, *spot)
 }

--- a/src/util/location/range/mod.rs
+++ b/src/util/location/range/mod.rs
@@ -3,8 +3,8 @@ use super::spot::Spot;
 /// A range representing the span of multiple characters in a multi-line text.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Range {
-    begin: Spot,
-    end: Spot,
+    pub begin: Spot,
+    pub end: Spot,
 }
 
 impl Range {

--- a/src/util/location/range/mod.rs
+++ b/src/util/location/range/mod.rs
@@ -11,15 +11,6 @@ impl Range {
     pub const fn new(begin: Spot, end: Spot) -> Self {
         Range { begin, end }
     }
-
-    pub const fn from_spot(spot: &Spot) -> Self {
-        Range { begin: *spot, end: *spot }
-    }
-}
-
-#[deprecated]
-pub const fn from_spot(spot: &Spot) -> Range {
-    Range::new(*spot, *spot)
 }
 
 #[cfg(test)]

--- a/src/util/location/spot/mod.rs
+++ b/src/util/location/spot/mod.rs
@@ -11,6 +11,8 @@ impl Spot {
     }
 }
 
+pub const ORIGIN: Spot = Spot::new(0, 0);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,9 +1,11 @@
 pub mod exec_fmt;
 pub mod location;
+pub mod scanner;
 pub mod string;
 pub mod tape;
 
 pub use location::range;
 pub use location::range::Range;
 pub use location::spot::Spot;
+pub use scanner::Scanner;
 pub use tape::Tape;

--- a/src/util/scanner/mod.rs
+++ b/src/util/scanner/mod.rs
@@ -1,0 +1,10 @@
+use crate::util::Range;
+
+/// Reading units one by one with spanning the location.
+pub trait Scanner {
+    type Item;
+
+    fn read(&self) -> Option<Self::Item>;
+    fn advance(&mut self) -> ();
+    fn locate(&self) -> Range;
+}


### PR DESCRIPTION
refactors:
- add scanner trait
- shorten commonly used long named types
- name better

(extra) chore:
- add ci command (to run in local)