### PR TITLE
format execution result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "komi"
 version = "0.1.0"
 dependencies = [
+ "const_format",
  "wasm-bindgen",
 ]
 
@@ -73,6 +94,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 wasm-bindgen = "0.2.100"
+const_format = "0.2.34"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/core/engine/evaluator/mod.rs
+++ b/src/core/engine/evaluator/mod.rs
@@ -49,7 +49,7 @@ mod tests {
     ];
 
     #[test]
-    fn fake_evaluate() -> Res {
+    fn test_single_num() -> Res {
         let ast = Ast::new(AstKind::Number(1.0), RANGE_MOCKS[0]);
 
         let value = evaluate(&ast)?;

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -116,7 +116,7 @@ mod tests {
     type Res = Result<(), LexError>;
 
     #[test]
-    fn test_lex_num_int() -> Res {
+    fn test_lex_num_without_decimal() -> Res {
         let source = "123";
 
         let token = Lexer::new(source).lex()?;
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lex_num_float() -> Res {
+    fn test_lex_num_with_decimal() -> Res {
         let source = "12.25"; // chosen to be equal on float comparison
 
         let token = Lexer::new(source).lex()?;

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -29,7 +29,10 @@ impl<'a> Lexer<'a> {
             match self.scanner.read() {
                 Some(s) if string::is_ascii_single_digit(s) => tokens.push(self.lex_num()?),
                 Some(x) => {
-                    return Err(LexError::IllegalChar(x.to_string(), self.scanner.locate()));
+                    return Err(LexError::IllegalChar {
+                        char: x.to_string(),
+                        location: self.scanner.locate(),
+                    });
                 }
                 None => {
                     break;
@@ -53,10 +56,10 @@ impl<'a> Lexer<'a> {
                 }
                 Some(s) if !string::is_ascii_single_whitespace(s) && s != "." => {
                     let end = self.scanner.locate().begin;
-                    return Err(LexError::BadNumLiteral(
-                        s.to_string(),
-                        Range::new(begin, end),
-                    ));
+                    return Err(LexError::BadNumLiteral {
+                        char: s.to_string(),
+                        location: Range::new(begin, end),
+                    });
                 }
                 _ => {
                     break;
@@ -84,10 +87,10 @@ impl<'a> Lexer<'a> {
                 }
                 Some(s) if !string::is_ascii_single_whitespace(s) => {
                     let end = self.scanner.locate().begin;
-                    return Err(LexError::BadNumLiteral(
-                        s.to_string(),
-                        Range::new(begin, end),
-                    ));
+                    return Err(LexError::BadNumLiteral {
+                        char: s.to_string(),
+                        location: Range::new(begin, end),
+                    });
                 }
                 _ => {
                     break;
@@ -149,7 +152,13 @@ mod tests {
 
         let token = Lexer::new(source).lex();
 
-        assert!(matches!(token, Err(LexError::BadNumLiteral(_, _))));
+        assert!(matches!(
+            token,
+            Err(LexError::BadNumLiteral {
+                char: _,
+                location: _
+            })
+        ));
         Ok(())
     }
 
@@ -159,7 +168,13 @@ mod tests {
 
         let token = Lexer::new(source).lex();
 
-        assert!(matches!(token, Err(LexError::IllegalChar(_, _))));
+        assert!(matches!(
+            token,
+            Err(LexError::IllegalChar {
+                char: _,
+                location: _
+            })
+        ));
         Ok(())
     }
 }

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -68,7 +68,7 @@ impl<'a> Lexer<'a> {
             let num = lexeme.parse::<f64>().unwrap();
             let end = self.scanner.locate().begin;
 
-            let token = Token::new(TokenKind::Number(num), Range::new(begin, end));
+            let token = Token::from_num(num, Range::new(begin, end));
             return Ok(token);
         }
 
@@ -98,7 +98,7 @@ impl<'a> Lexer<'a> {
         let num = lexeme.parse::<f64>().unwrap();
         let end = self.scanner.locate().begin;
 
-        let token = Token::new(TokenKind::Number(num), Range::new(begin, end));
+        let token = Token::from_num(num, Range::new(begin, end));
         return Ok(token);
     }
 }

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -116,7 +116,7 @@ mod tests {
     type Res = Result<(), LexError>;
 
     #[test]
-    fn lex_num_int() -> Res {
+    fn test_lex_num_int() -> Res {
         let source = "123";
 
         let token = Lexer::new(source).lex()?;
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn lex_num_float() -> Res {
+    fn test_lex_num_float() -> Res {
         let source = "12.25"; // chosen to be equal on float comparison
 
         let token = Lexer::new(source).lex()?;
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn lex_num_fail() -> Res {
+    fn test_lex_num_fail() -> Res {
         let source = "12a";
 
         let token = Lexer::new(source).lex();
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn lex_fail() -> Res {
+    fn test_lex_fail() -> Res {
         let source = " ";
 
         let token = Lexer::new(source).lex();

--- a/src/core/engine/parser/mod.rs
+++ b/src/core/engine/parser/mod.rs
@@ -62,7 +62,7 @@ mod tests {
     ];
 
     #[test]
-    fn parse_num() -> Res {
+    fn test_parse_num() -> Res {
         let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
 
         let ast = parse(&tokens)?;

--- a/src/core/engine/representor/mod.rs
+++ b/src/core/engine/representor/mod.rs
@@ -17,7 +17,7 @@ mod tests {
     ];
 
     #[test]
-    fn repr_num() {
+    fn test_repr_num() {
         let value = Value::new(ValueKind::Number(1.0), RANGE_MOCKS[0]);
 
         let repr = represent(&value);

--- a/src/core/err/lex/mod.rs
+++ b/src/core/err/lex/mod.rs
@@ -6,22 +6,24 @@ use std::fmt;
 /// Serves as the interface between a lexer and its user.
 #[derive(Debug)]
 pub enum LexError {
-    IllegalChar(String, Range),
-    BadNumLiteral(String, Range),
+    /// An illegal char, not in the syntax.
+    IllegalChar { char: String, location: Range },
+    /// An illegal number char.
+    BadNumLiteral { char: String, location: Range },
 }
 
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            LexError::IllegalChar(str, location) => write!(
+            LexError::IllegalChar { char, location } => write!(
                 f,
                 "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
-                str, location
+                char, location
             ),
-            LexError::BadNumLiteral(str, location) => write!(
+            LexError::BadNumLiteral { char, location } => write!(
                 f,
                 "Reason: LEX_BAD_NUM_LITERAL, Cause: '{}', Location: {:?}",
-                str, location
+                char, location
             ),
         }
     }

--- a/src/core/err/mod.rs
+++ b/src/core/err/mod.rs
@@ -10,36 +10,36 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum ExecError {
-    LexError(LexError),
-    ParseError(ParseError),
-    EvalError(EvalError),
+    Lex(LexError),
+    Parse(ParseError),
+    Eval(EvalError),
 }
 
 impl<'a> fmt::Display for ExecError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ExecError::LexError(err) => err.fmt(f),
-            ExecError::ParseError(err) => err.fmt(f),
-            ExecError::EvalError(err) => err.fmt(f),
+            ExecError::Lex(err) => err.fmt(f),
+            ExecError::Parse(err) => err.fmt(f),
+            ExecError::Eval(err) => err.fmt(f),
         }
     }
 }
 
 impl From<LexError> for ExecError {
     fn from(err: LexError) -> Self {
-        ExecError::LexError(err)
+        ExecError::Lex(err)
     }
 }
 
 impl From<ParseError> for ExecError {
     fn from(err: ParseError) -> Self {
-        ExecError::ParseError(err)
+        ExecError::Parse(err)
     }
 }
 
 impl From<EvalError> for ExecError {
     fn from(err: EvalError) -> Self {
-        ExecError::EvalError(err)
+        ExecError::Eval(err)
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,10 +1,12 @@
 mod engine;
-mod err;
+pub mod err;
 mod syntax;
 
 pub use err::ExecError;
 
-pub fn execute(source: &str) -> Result<String, ExecError> {
+pub type ExecResult = Result<String, ExecError>;
+
+pub fn execute(source: &str) -> ExecResult {
     let tokens = engine::lex(&source)?;
     let ast = engine::parse(&tokens)?;
     let value = engine::evaluate(&ast)?;
@@ -33,7 +35,7 @@ mod tests {
         let source = " ";
         let executed = execute(source);
 
-        assert!(matches!(executed, Err(ExecError::LexError(_))));
+        assert!(matches!(executed, Err(ExecError::Lex(_))));
         Ok(())
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,7 +22,7 @@ mod tests {
     type Res = Result<(), ExecError>;
 
     #[test]
-    fn should_work() -> Res {
+    fn test_single_number_literal() -> Res {
         let source = "12.25";
         let executed = execute(source)?;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,7 +22,16 @@ mod tests {
     type Res = Result<(), ExecError>;
 
     #[test]
-    fn test_single_number_literal() -> Res {
+    fn test_single_number_literal_without_decimal() -> Res {
+        let source = "12";
+        let executed = execute(source)?;
+
+        assert_eq!(executed, "12");
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_number_literal_with_decimal() -> Res {
         let source = "12.25";
         let executed = execute(source)?;
 

--- a/src/core/syntax/ast/mod.rs
+++ b/src/core/syntax/ast/mod.rs
@@ -30,7 +30,7 @@ mod tests {
     use crate::util::Spot;
 
     #[test]
-    fn new() {
+    fn test_new() {
         let range = Range::new(Spot::new(1, 2), Spot::new(3, 4));
         let ast = Ast::new(AstKind::Number(1.0), range.clone());
 

--- a/src/core/syntax/token/mod.rs
+++ b/src/core/syntax/token/mod.rs
@@ -30,7 +30,7 @@ mod tests {
     use crate::util::Spot;
 
     #[test]
-    fn new() {
+    fn test_new() {
         let range = Range::new(Spot::new(1, 2), Spot::new(3, 4));
         let token = Token::new(TokenKind::Number(1.0), range.clone());
 
@@ -44,7 +44,7 @@ mod tests {
     }
 
     #[test]
-    fn from_num() {
+    fn test_from_num() {
         let range = Range::new(Spot::new(1, 2), Spot::new(3, 4));
         let token = Token::from_num(1.0, range.clone());
 

--- a/src/core/syntax/token/mod.rs
+++ b/src/core/syntax/token/mod.rs
@@ -29,30 +29,30 @@ mod tests {
     use super::*;
     use crate::util::Spot;
 
+    const RANGE_MOCK: Range = Range::new(Spot::new(1, 2), Spot::new(3, 4));
+
     #[test]
     fn test_new() {
-        let range = Range::new(Spot::new(1, 2), Spot::new(3, 4));
-        let token = Token::new(TokenKind::Number(1.0), range.clone());
+        let token = Token::new(TokenKind::Number(1.0), RANGE_MOCK);
 
         assert_eq!(
             token,
             Token {
                 kind: TokenKind::Number(1.0),
-                location: range
+                location: RANGE_MOCK,
             }
         )
     }
 
     #[test]
     fn test_from_num() {
-        let range = Range::new(Spot::new(1, 2), Spot::new(3, 4));
-        let token = Token::from_num(1.0, range.clone());
+        let token = Token::from_num(1.0, RANGE_MOCK);
 
         assert_eq!(
             token,
             Token {
                 kind: TokenKind::Number(1.0),
-                location: range
+                location: RANGE_MOCK,
             }
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,26 @@
 mod core;
 mod util;
 
-use util::exec_fmt;
+use util::exec_fmt::format;
 
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn execute(source: &str) -> String {
-    match core::execute(source) {
-        Ok(s) => exec_fmt::fmt_ok(&s),
-        Err(e) => exec_fmt::fmt_err(e),
-    }
+    format(core::execute(source))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use util::exec_fmt::is_err_format;
 
     #[test]
     fn test_execute() {
         let source = "1";
         let executed = execute(source);
 
-        assert_eq!(executed, exec_fmt::fmt_ok("1"));
+        assert_eq!(executed, "komi v1 ok 1")
     }
 
     #[test]
@@ -30,18 +28,6 @@ mod tests {
         let source = " ";
         let executed = execute(source);
 
-        assert_err(&executed);
-    }
-
-    fn assert_err(executed: &str) -> () {
-        assert!(
-            is_err(&executed),
-            "Expected an error, but received '{}'",
-            executed
-        );
-    }
-
-    fn is_err(executed: &str) -> bool {
-        executed.starts_with("{ \"err\": \"")
+        assert!(executed.starts_with("komi v1 err"));
     }
 }

--- a/src/util/exec_fmt/mod.rs
+++ b/src/util/exec_fmt/mod.rs
@@ -60,7 +60,10 @@ mod tests {
 
     #[test]
     fn test_format_err() {
-        let some_lex_error = LexError::IllegalChar("bad".to_string(), RANGE_MOCK);
+        let some_lex_error = LexError::IllegalChar {
+            char: "bad".to_string(),
+            location: RANGE_MOCK,
+        };
         let res = Err(ExecError::Lex(some_lex_error));
 
         let formatted = format(res);

--- a/src/util/exec_fmt/mod.rs
+++ b/src/util/exec_fmt/mod.rs
@@ -1,9 +1,161 @@
-use crate::core::ExecError;
+mod v1;
 
-pub fn fmt_ok(s: &str) -> String {
-    format!("{{ \"ok\": \"{s}\" }}")
+use crate::core::ExecResult;
+use const_format::formatcp;
+
+const MAGIC: &str = "komi";
+const VER1: &str = "v1";
+const HEADER_VER1: &str = formatcp!("{MAGIC} {VER1}");
+
+/// Formats an execution result.
+/// The formatted string always begins with the header `komi v1`.
+///
+/// For a successful result with a `repr` representation, returns `komi v1 ok repr`.
+/// For a failed result with an `error` message, returns `komi v1 err error`.
+pub fn format(res: ExecResult) -> String {
+    let payload = v1::format(res);
+    format!("{MAGIC} {VER1} {payload}")
 }
 
-pub fn fmt_err(e: ExecError) -> String {
-    format!("{{ \"err\": \"{e}\" }}")
+pub fn is_ok_format(str: &str) -> bool {
+    has_valid_header(str) && has_valid_ok_payload(str)
+}
+
+pub fn is_err_format(str: &str) -> bool {
+    has_valid_header(str) && has_valid_err_payload(str)
+}
+
+fn has_valid_header(str: &str) -> bool {
+    str.starts_with(HEADER_VER1)
+}
+
+fn has_valid_ok_payload(str: &str) -> bool {
+    let base_index = HEADER_VER1.len() + 1;
+    str.len() >= base_index && v1::is_ok_format(&str[base_index..])
+}
+
+fn has_valid_err_payload(str: &str) -> bool {
+    let base_index = HEADER_VER1.len() + 1;
+    str.len() >= base_index && v1::is_err_format(&str[base_index..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ExecError;
+    use crate::core::err::LexError;
+    use crate::util::{Range, Spot};
+
+    const RANGE_MOCK: Range = Range::new(Spot::new(0, 0), Spot::new(0, 1));
+
+    #[test]
+    fn test_format_ok() {
+        let res = Ok("some ok result".to_string());
+
+        let formatted = format(res);
+
+        let expected = "komi v1 ok some ok result";
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn test_format_err() {
+        let some_lex_error = LexError::IllegalChar("bad".to_string(), RANGE_MOCK);
+        let res = Err(ExecError::Lex(some_lex_error));
+
+        let formatted = format(res);
+
+        let expected = "komi v1 err Reason: LEX_ILLEGAL_CHAR, Cause: 'bad', Location: Range { begin: Spot { row: 0, col: 0 }, end: Spot { row: 0, col: 1 } }";
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn test_is_ok_format_true() {
+        let str = "komi v1 ok some result";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, true);
+    }
+
+    #[test]
+    fn test_is_ok_format_false_for_bad_magic() {
+        let str = "bad v1 ok some result";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_ok_format_false_for_bad_ver() {
+        let str = "komi bad ok some result";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_ok_format_false_for_empty() {
+        let str = "";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_ok_format_false_for_empty_payload() {
+        let str = "komi v1";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_err_format_true() {
+        let str = "komi v1 err some result";
+
+        let err = is_err_format(str);
+
+        assert_eq!(err, true);
+    }
+
+    #[test]
+    fn test_is_err_format_false_for_bad_magic() {
+        let str = "bad v1 err some result";
+
+        let err = is_err_format(str);
+
+        assert_eq!(err, false);
+    }
+
+    #[test]
+    fn test_is_err_format_false_for_bad_ver() {
+        let str = "komi bad err some result";
+
+        let err = is_err_format(str);
+
+        assert_eq!(err, false);
+    }
+
+    #[test]
+    fn test_is_err_format_false_for_payload() {
+        let str = "";
+
+        let err = is_err_format(str);
+
+        assert_eq!(err, false);
+    }
+
+    #[test]
+    fn test_is_err_format_false_for_empty_payload() {
+        let str = "komi v1";
+
+        let err = is_err_format(str);
+
+        assert_eq!(err, false);
+    }
 }

--- a/src/util/exec_fmt/v1/mod.rs
+++ b/src/util/exec_fmt/v1/mod.rs
@@ -1,0 +1,116 @@
+use crate::core::ExecError;
+use crate::core::ExecResult;
+
+const OK_HEADER: &str = "ok";
+const ERR_HEADER: &str = "err";
+
+/// Formats an execution result.
+///
+/// For a successful result with a `repr` representation, returns `ok repr`.
+/// For a failed result with an `error` message, returns `err error`.
+pub fn format(res: ExecResult) -> String {
+    match res {
+        Ok(str) => format_ok(&str),
+        Err(err) => format_err(err),
+    }
+}
+
+pub fn is_ok_format(str: &str) -> bool {
+    str.starts_with(&format!("{} ", OK_HEADER))
+}
+
+pub fn is_err_format(str: &str) -> bool {
+    str.starts_with(&format!("{} ", ERR_HEADER))
+}
+
+fn format_ok(payload: &str) -> String {
+    format!("{} {}", OK_HEADER, payload.to_string())
+}
+
+fn format_err(err: ExecError) -> String {
+    format!("{} {}", ERR_HEADER, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::err::LexError;
+    use crate::util::{Range, Spot};
+
+    const RANGE_MOCK: Range = Range::new(Spot::new(0, 0), Spot::new(0, 1));
+
+    #[test]
+    fn test_format_ok() {
+        let res = Ok("some result".to_string());
+
+        let formatted = format(res);
+
+        let expected = "ok some result";
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn test_format_err() {
+        let some_lex_error = LexError::IllegalChar("bad".to_string(), RANGE_MOCK);
+        let res = Err(ExecError::Lex(some_lex_error));
+
+        let formatted = format(res);
+
+        let expected = "err Reason: LEX_ILLEGAL_CHAR, Cause: 'bad', Location: Range { begin: Spot { row: 0, col: 0 }, end: Spot { row: 0, col: 1 } }";
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn test_is_ok_format_true() {
+        let str = "ok some result";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, true);
+    }
+
+    #[test]
+    fn test_is_ok_format_false_for_bad_header() {
+        let str = "bad some result";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_ok_format_false_for_empty_result() {
+        let str = "ok";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_err_format_true() {
+        let str = "err some message";
+
+        let err = is_err_format(str);
+
+        assert_eq!(err, true);
+    }
+
+    #[test]
+    fn test_is_err_format_false_for_bad_header() {
+        let str = "bad some message";
+
+        let ok = is_err_format(str);
+
+        assert_eq!(ok, false);
+    }
+
+    #[test]
+    fn test_is_err_format_false_for_empty_result() {
+        let str = "err";
+
+        let ok = is_ok_format(str);
+
+        assert_eq!(ok, false);
+    }
+}

--- a/src/util/exec_fmt/v1/mod.rs
+++ b/src/util/exec_fmt/v1/mod.rs
@@ -51,7 +51,10 @@ mod tests {
 
     #[test]
     fn test_format_err() {
-        let some_lex_error = LexError::IllegalChar("bad".to_string(), RANGE_MOCK);
+        let some_lex_error = LexError::IllegalChar {
+            char: "bad".to_string(),
+            location: RANGE_MOCK,
+        };
         let res = Err(ExecError::Lex(some_lex_error));
 
         let formatted = format(res);


### PR DESCRIPTION
feats:
- new string interface for execution with format v1

(extra) refactor:
- make test case name consistent
- make error enums more descriptive
- factor out constants into mocks in testing