### PR TITLE
test lexing arithmetic symbols

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+hard_tabs=false
+match_arm_leading_pipes="never"
+match_block_trailing_comma=false
+max_width=120
+merge_derives=true
+newline_style="auto"
+remove_nested_parens=true
+reorder_imports=true
+reorder_modules=true
+tab_spaces=4
+edition="2024"

--- a/src/core/engine/evaluator/mod.rs
+++ b/src/core/engine/evaluator/mod.rs
@@ -39,10 +39,7 @@ impl<'a> Evaluator<'a> {
         if let ValueKind::Number(num) = val.kind {
             Ok(num)
         } else {
-            Err(EvalError::BadAdditionOperand(
-                format!("{:?}", val.kind),
-                val.location,
-            ))
+            Err(EvalError::BadAdditionOperand(format!("{:?}", val.kind), val.location))
         }
     }
 

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -268,16 +268,60 @@ mod tests {
         }
     }
 
-    mod plus {
+    mod single_chars {
         use super::*;
 
         #[test]
-        fn test_lex() -> Res {
+        fn test_lex_plus() -> Res {
             let source = "+";
 
             let token = Lexer::new(source).lex()?;
 
-            let expected = vec![Token::new(TokenKind::Plus, Range::from_nums(0, 0, 0, "+".len() as u64))];
+            let expected = vec![Token::new(TokenKind::Plus, Range::from_nums(0, 0, 0, 1))];
+            assert_eq!(token, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn test_lex_minus() -> Res {
+            let source = "-";
+
+            let token = Lexer::new(source).lex()?;
+
+            let expected = vec![Token::new(TokenKind::Minus, Range::from_nums(0, 0, 0, 1))];
+            assert_eq!(token, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn test_lex_asterisk() -> Res {
+            let source = "*";
+
+            let token = Lexer::new(source).lex()?;
+
+            let expected = vec![Token::new(TokenKind::Asterisk, Range::from_nums(0, 0, 0, 1))];
+            assert_eq!(token, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn test_lex_slash() -> Res {
+            let source = "/";
+
+            let token = Lexer::new(source).lex()?;
+
+            let expected = vec![Token::new(TokenKind::Slash, Range::from_nums(0, 0, 0, 1))];
+            assert_eq!(token, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn test_lex_percent() -> Res {
+            let source = "%";
+
+            let token = Lexer::new(source).lex()?;
+
+            let expected = vec![Token::new(TokenKind::Percent, Range::from_nums(0, 0, 0, 1))];
             assert_eq!(token, expected);
             Ok(())
         }

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -27,12 +27,30 @@ impl<'a> Lexer<'a> {
 
         loop {
             match self.scanner.read() {
-                Some(s) if string::is_digit(s) => tokens.push(self.advance_and_lex_with_first_char(Self::lex_num, s)?),
-                Some("+") => tokens.push(self.advance_and_lex(Self::lex_plus)?),
-                Some("-") => tokens.push(self.advance_and_lex(Self::lex_minus)?),
-                Some("*") => tokens.push(self.advance_and_lex(Self::lex_asterisk)?),
-                Some("/") => tokens.push(self.advance_and_lex(Self::lex_slash)?),
-                Some("%") => tokens.push(self.advance_and_lex(Self::lex_percent)?),
+                Some(s) if string::is_digit(s) => {
+                    let token = self.advance_and_lex_with_first_char(Self::lex_num, s)?;
+                    tokens.push(token);
+                }
+                Some("+") => {
+                    let token = self.advance_and_lex(Self::lex_plus)?;
+                    tokens.push(token);
+                }
+                Some("-") => {
+                    let token = self.advance_and_lex(Self::lex_minus)?;
+                    tokens.push(token);
+                }
+                Some("*") => {
+                    let token = self.advance_and_lex(Self::lex_asterisk)?;
+                    tokens.push(token);
+                }
+                Some("/") => {
+                    let token = self.advance_and_lex(Self::lex_slash)?;
+                    tokens.push(token);
+                }
+                Some("%") => {
+                    let token = self.advance_and_lex(Self::lex_percent)?;
+                    tokens.push(token);
+                }
                 Some("#") => {
                     self.scanner.advance();
                     self.skip_comment();
@@ -67,7 +85,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn advance_and_lex<F>(&mut self, lex: F) -> Result<Token, LexError>
+    fn advance_and_lex<F>(&mut self, lex: F) -> ResToken
     where
         F: FnOnce(&mut Self, Range) -> ResToken,
     {
@@ -76,7 +94,7 @@ impl<'a> Lexer<'a> {
         lex(self, first_location)
     }
 
-    fn advance_and_lex_with_first_char<F>(&mut self, lex: F, first_char: &'a str) -> Result<Token, LexError>
+    fn advance_and_lex_with_first_char<F>(&mut self, lex: F, first_char: &'a str) -> ResToken
     where
         F: FnOnce(&mut Self, Range, &'a str) -> ResToken,
     {

--- a/src/core/engine/lexer/mod.rs
+++ b/src/core/engine/lexer/mod.rs
@@ -27,9 +27,7 @@ impl<'a> Lexer<'a> {
 
         loop {
             match self.scanner.read() {
-                Some(s) if string::is_digit(s) => {
-                    tokens.push(self.advance_and_lex_with_first_char(Self::lex_num, s)?)
-                }
+                Some(s) if string::is_digit(s) => tokens.push(self.advance_and_lex_with_first_char(Self::lex_num, s)?),
                 Some("+") => tokens.push(self.advance_and_lex(Self::lex_plus)?),
                 Some("-") => tokens.push(self.advance_and_lex(Self::lex_minus)?),
                 Some("*") => tokens.push(self.advance_and_lex(Self::lex_asterisk)?),
@@ -78,11 +76,7 @@ impl<'a> Lexer<'a> {
         lex(self, first_location)
     }
 
-    fn advance_and_lex_with_first_char<F>(
-        &mut self,
-        lex: F,
-        first_char: &'a str,
-    ) -> Result<Token, LexError>
+    fn advance_and_lex_with_first_char<F>(&mut self, lex: F, first_char: &'a str) -> Result<Token, LexError>
     where
         F: FnOnce(&mut Self, Range, &'a str) -> ResToken,
     {
@@ -283,10 +277,7 @@ mod tests {
 
             let token = Lexer::new(source).lex()?;
 
-            let expected = vec![Token::new(
-                TokenKind::Plus,
-                Range::from_nums(0, 0, 0, "+".len() as u64),
-            )];
+            let expected = vec![Token::new(TokenKind::Plus, Range::from_nums(0, 0, 0, "+".len() as u64))];
             assert_eq!(token, expected);
             Ok(())
         }
@@ -302,10 +293,7 @@ mod tests {
             let token = Lexer::new(source).lex()?;
 
             let expected = vec![
-                Token::new(
-                    TokenKind::Number(12.0),
-                    Range::from_nums(0, 0, 0, "12".len() as u64),
-                ),
+                Token::new(TokenKind::Number(12.0), Range::from_nums(0, 0, 0, "12".len() as u64)),
                 Token::new(
                     TokenKind::Plus,
                     Range::from_nums(0, "12 ".len() as u64, 0, "12 +".len() as u64),

--- a/src/core/engine/lexer/source_scanner/mod.rs
+++ b/src/core/engine/lexer/source_scanner/mod.rs
@@ -20,7 +20,7 @@ impl<'a> SourceScanner<'a> {
 }
 
 impl<'a> Scanner for SourceScanner<'a> {
-    type Item = &'a str;
+    type Item = Option<&'a str>;
 
     fn read(&self) -> Option<&'a str> {
         match self.tape.get_current() {

--- a/src/core/engine/lexer/utf8_tape/mod.rs
+++ b/src/core/engine/lexer/utf8_tape/mod.rs
@@ -20,10 +20,7 @@ impl<'a> Utf8Tape<'a> {
             base += size;
         }
 
-        Self {
-            chars,
-            base_index: 0,
-        }
+        Self { chars, base_index: 0 }
     }
 }
 

--- a/src/core/engine/parser/token_scanner/mod.rs
+++ b/src/core/engine/parser/token_scanner/mod.rs
@@ -27,9 +27,9 @@ impl<'a> TokenScanner<'a> {
 }
 
 impl<'a> Scanner for TokenScanner<'a> {
-    type Item = &'a Token;
+    type Item = Option<&'a Token>;
 
-    fn read(&self) -> Option<Self::Item> {
+    fn read(&self) -> Self::Item {
         self.tokens.get(self.base_index)
     }
 

--- a/src/core/err/eval/mod.rs
+++ b/src/core/err/eval/mod.rs
@@ -18,11 +18,9 @@ impl<'a> fmt::Display for EvalError {
                 "Reason: EVAL_BAD_ADDITION_OPERAND, Cause: '{}', Location: {:?}",
                 str, location
             ),
-            EvalError::Unexpected(str, location) => write!(
-                f,
-                "Reason: EVAL_UNEXPECTED, Cause: '{}', Location: {:?}",
-                str, location
-            ),
+            EvalError::Unexpected(str, location) => {
+                write!(f, "Reason: EVAL_UNEXPECTED, Cause: '{}', Location: {:?}", str, location)
+            }
         }
     }
 }

--- a/src/core/syntax/bp/mod.rs
+++ b/src/core/syntax/bp/mod.rs
@@ -4,10 +4,7 @@ pub struct Bp {
     pub right: u8,
 }
 
-static LOWEST_BP: Bp = Bp {
-    left: 0o0,
-    right: 0o1,
-};
+static LOWEST_BP: Bp = Bp { left: 0o0, right: 0o1 };
 static SUMMATIVE_BP: Bp = Bp {
     left: 0o30,
     right: 0o31,

--- a/src/util/scanner/mod.rs
+++ b/src/util/scanner/mod.rs
@@ -4,7 +4,7 @@ use crate::util::Range;
 pub trait Scanner {
     type Item;
 
-    fn read(&self) -> Option<Self::Item>;
+    fn read(&self) -> Self::Item;
     fn advance(&mut self) -> ();
     fn locate(&self) -> Range;
 }


### PR DESCRIPTION
test added

extra:
- specify formatting rule (`rustfmt.toml`)
- re-format and refactor some codes
- correct some type 