### PR TITLE
support empty program execution

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -6,4 +6,4 @@ mod representor;
 pub use evaluator::evaluate;
 pub use lexer::lex;
 pub use parser::parse;
-pub use representor::represent;
+pub use representor::{EMPTY_REPR, represent};

--- a/src/core/engine/representor/mod.rs
+++ b/src/core/engine/representor/mod.rs
@@ -1,11 +1,15 @@
 use crate::core::syntax::{Value, ValueKind};
 
+pub const EMPTY_REPR: &str = "(EMPTY)";
+
 pub fn represent(val: &Value) -> String {
     match val.kind {
         ValueKind::Number(n) => n.to_string(),
+        ValueKind::Empty => EMPTY_REPR.to_string(),
     }
 }
 
+/// Note: Use the constant `EMPTY_REPR` to test the representation of the empty value, to avoid depending on the implementation detail.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -13,14 +17,35 @@ mod tests {
 
     const RANGE_MOCKS: &[Range] = &[Range::from_nums(0, 0, 0, 1), Range::from_nums(0, 1, 0, 2)];
 
-    #[test]
-    fn test_repr_num() {
-        let value = Value::new(ValueKind::Number(1.0), RANGE_MOCKS[0]);
+    mod parts {
+        use super::*;
 
-        let repr = represent(&value);
+        /// Represents `1`.
+        #[test]
+        fn test_num() {
+            let value = Value::new(ValueKind::Number(1.0), RANGE_MOCKS[0]);
 
-        let expected = "1";
+            let repr = represent(&value);
 
-        assert_eq!(repr, expected);
+            let expected = "1";
+
+            assert_eq!(repr, expected);
+        }
+    }
+
+    mod programs {
+        use super::*;
+
+        /// Represents ``.
+        #[test]
+        fn test_empty() {
+            let value = Value::new(ValueKind::Empty, Range::from_nums(0, 0, 0, 0));
+
+            let repr = represent(&value);
+
+            let expected = EMPTY_REPR;
+
+            assert_eq!(repr, expected);
+        }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@ mod engine;
 pub mod err;
 mod syntax;
 
+pub use engine::EMPTY_REPR;
 pub use err::ExecError;
 
 pub type ExecResult = Result<String, ExecError>;

--- a/src/core/syntax/ast/mod.rs
+++ b/src/core/syntax/ast/mod.rs
@@ -1,9 +1,10 @@
-use crate::util::Range;
+use crate::util::{Range, range};
 
 /// Kinds of AST produced during parsing.
 /// Serves as the interface between a parser and its user.
 #[derive(Debug, PartialEq, Clone)]
 pub enum AstKind {
+    Program { expressions: Vec<Ast> },
     Number(f64),
     InfixPlus { left: Box<Ast>, right: Box<Ast> },
 }
@@ -20,6 +21,12 @@ impl Ast {
         Ast { kind, location }
     }
 
+    pub fn from_program(expressions: Vec<Ast>) -> Self {
+        let location = Self::locate_expressions(&expressions);
+
+        Ast::new(AstKind::Program { expressions }, location)
+    }
+
     pub fn from_num(num: f64, location: Range) -> Self {
         Ast::new(AstKind::Number(num), location)
     }
@@ -31,6 +38,17 @@ impl Ast {
             right: Box::new(right),
         };
         Ast::new(kind, location)
+    }
+
+    fn locate_expressions(expressions: &Vec<Ast>) -> Range {
+        if expressions.len() == 0 {
+            return range::ORIGIN;
+        }
+
+        Range {
+            begin: expressions[0].location.begin,
+            end: expressions[expressions.len() - 1].location.end,
+        }
     }
 }
 

--- a/src/core/syntax/value/mod.rs
+++ b/src/core/syntax/value/mod.rs
@@ -5,6 +5,7 @@ use crate::util::Range;
 #[derive(Debug, PartialEq)]
 pub enum ValueKind {
     Number(f64),
+    Empty,
 }
 
 /// A representation of the value produced during evaluation.
@@ -21,5 +22,9 @@ impl Value {
 
     pub fn from_num(num: f64, location: Range) -> Self {
         Value::new(ValueKind::Number(num), location)
+    }
+
+    pub fn from_empty(location: Range) -> Self {
+        Value::new(ValueKind::Empty, location)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@ pub fn execute(source: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use util::exec_fmt::is_err_format;
+    use crate::core::EMPTY_REPR;
 
     #[test]
-    fn test_execute() {
+    fn test_execute_num() {
         let source = "1";
         let executed = execute(source);
 
@@ -24,10 +24,10 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_fail() {
+    fn test_execute_empty() {
         let source = " ";
         let executed = execute(source);
 
-        assert!(executed.starts_with("komi v1 err"));
+        assert_eq!(executed, format!("komi v1 ok {}", EMPTY_REPR))
     }
 }


### PR DESCRIPTION
**parser and evaluator**: wraps the result with program, for examples:
- ast parsing number:
  - previous: `number token` -> `number ast`
  - current: `number token` -> `program ast { number ast }`
- ast parsing empty program:
  - previous: `empty` -> error
  - previous: `empty` -> `program ast {}`
- value
  - previous: `empty` -> error
  - current: `empty` -> `empty value`

**representator**: converts empty program into the representation of the empty value