### PR TITLE
correct lexing number literals with comma

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -105,6 +105,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore] // TODO
         fn test_number_ending_with_dot() -> Res {
             assert_exec!("12.", "12");
         }

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -21,7 +21,7 @@ pub fn execute(source: &str) -> ExecResult {
 #[cfg(test)]
 mod tests {
     use super::{EMPTY_REPR, ExecError, execute};
-    use komi_lexer::LexError;
+    use komi_lexer::{LexError, LexErrorKind};
     use komi_util::Range;
 
     type Res = Result<(), ExecError>;
@@ -182,10 +182,11 @@ mod tests {
         fn test_dot() -> Res {
             assert_exec_fail!(
                 ".",
-                ExecError::Lex(LexError::IllegalChar {
-                    cause: ".".to_string(),
-                    location: Range::from_nums(0, 0, 0, 1),
-                })
+                ExecError::Lex(LexError::new(
+                    LexErrorKind::IllegalChar,
+                    ".".to_string(),
+                    Range::from_nums(0, 0, 0, 1),
+                ))
             );
         }
 
@@ -193,10 +194,11 @@ mod tests {
         fn test_two_dots() -> Res {
             assert_exec_fail!(
                 "..",
-                ExecError::Lex(LexError::IllegalChar {
-                    cause: ".".to_string(),
-                    location: Range::from_nums(0, 0, 0, 1),
-                })
+                ExecError::Lex(LexError::new(
+                    LexErrorKind::IllegalChar,
+                    ".".to_string(),
+                    Range::from_nums(0, 0, 0, 1),
+                ))
             );
         }
 
@@ -205,10 +207,11 @@ mod tests {
         fn test_two_pluses() -> Res {
             assert_exec_fail!(
                 "++",
-                ExecError::Lex(LexError::IllegalChar {
-                    cause: "+".to_string(),
-                    location: Range::from_nums(0, 1, 0, 2),
-                })
+                ExecError::Lex(LexError::new(
+                    LexErrorKind::IllegalChar,
+                    "+".to_string(),
+                    Range::from_nums(0, 1, 0, 2)
+                ))
             );
         }
 
@@ -217,10 +220,11 @@ mod tests {
         fn test_two_minuses() -> Res {
             assert_exec_fail!(
                 "--",
-                ExecError::Lex(LexError::IllegalChar {
-                    cause: "-".to_string(),
-                    location: Range::from_nums(0, 1, 0, 2),
-                })
+                ExecError::Lex(LexError::new(
+                    LexErrorKind::IllegalChar,
+                    "-".to_string(),
+                    Range::from_nums(0, 1, 0, 2)
+                ))
             );
         }
 

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
             assert_exec_fail!(
                 ".",
                 ExecError::Lex(LexError::IllegalChar {
-                    char: ".".to_string(),
+                    cause: ".".to_string(),
                     location: Range::from_nums(0, 0, 0, 1),
                 })
             );
@@ -194,7 +194,7 @@ mod tests {
             assert_exec_fail!(
                 "..",
                 ExecError::Lex(LexError::IllegalChar {
-                    char: ".".to_string(),
+                    cause: ".".to_string(),
                     location: Range::from_nums(0, 0, 0, 1),
                 })
             );
@@ -206,7 +206,7 @@ mod tests {
             assert_exec_fail!(
                 "++",
                 ExecError::Lex(LexError::IllegalChar {
-                    char: "+".to_string(),
+                    cause: "+".to_string(),
                     location: Range::from_nums(0, 1, 0, 2),
                 })
             );
@@ -218,7 +218,7 @@ mod tests {
             assert_exec_fail!(
                 "--",
                 ExecError::Lex(LexError::IllegalChar {
-                    char: "-".to_string(),
+                    cause: "-".to_string(),
                     location: Range::from_nums(0, 1, 0, 2),
                 })
             );

--- a/komi_lexer/src/err/mod.rs
+++ b/komi_lexer/src/err/mod.rs
@@ -7,31 +7,25 @@ use std::fmt;
 #[derive(Debug, PartialEq)]
 pub enum LexError {
     /// An illegal char, not in the syntax.
-    IllegalChar { char: String, location: Range },
+    IllegalChar { cause: String, location: Range },
     /// An illegal number literal, such as `12.`.
-    IllegalNumLiteral { bad_literal: String, location: Range },
+    IllegalNumLiteral { cause: String, location: Range },
     /// An internal error impossible to occur if lexed as expected.
-    Unexpected { expected: String, received: String, location: Range },
+    Unexpected { cause: String, location: Range },
+}
+
+macro_rules! write_lex_err {
+    ($fmt:ident, $reason:literal, $cause:ident, $loc: ident) => {
+        write!($fmt, "Reason: {}, Cause: '{}', Location: {:?}", $reason, $cause, $loc)
+    };
 }
 
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            LexError::IllegalChar { char, location } => write!(
-                f,
-                "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
-                char, location
-            ),
-            LexError::IllegalNumLiteral { bad_literal, location } => write!(
-                f,
-                "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
-                bad_literal, location
-            ),
-            LexError::Unexpected { expected, received, location } => write!(
-                f,
-                "Reason: LEX_UNEXPECTED, Cause: '{}', Expected: '{}', Location: {:?}",
-                received, expected, location
-            ),
+            LexError::IllegalChar { cause: c, location: l } => write_lex_err!(f, "LEX_ILLEGAL_CHAR", c, l),
+            LexError::IllegalNumLiteral { cause: c, location: l } => write_lex_err!(f, "LEX_ILLEGAL_NUM_LITERAL", c, l),
+            LexError::Unexpected { cause: c, location: l } => write_lex_err!(f, "LEX_UNEXPECTED", c, l),
         }
     }
 }

--- a/komi_lexer/src/err/mod.rs
+++ b/komi_lexer/src/err/mod.rs
@@ -8,6 +8,8 @@ use std::fmt;
 pub enum LexError {
     /// An illegal char, not in the syntax.
     IllegalChar { char: String, location: Range },
+    /// An illegal number literal, such as `12.`.
+    IllegalNumLiteral { bad_literal: String, location: Range },
     /// An internal error impossible to occur if lexed as expected.
     Unexpected { expected: String, received: String, location: Range },
 }
@@ -19,6 +21,11 @@ impl fmt::Display for LexError {
                 f,
                 "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
                 char, location
+            ),
+            LexError::IllegalNumLiteral { bad_literal, location } => write!(
+                f,
+                "Reason: LEX_ILLEGAL_CHAR, Cause: '{}', Location: {:?}",
+                bad_literal, location
             ),
             LexError::Unexpected { expected, received, location } => write!(
                 f,

--- a/komi_lexer/src/err/mod.rs
+++ b/komi_lexer/src/err/mod.rs
@@ -2,31 +2,62 @@ use komi_util::Range;
 use std::error::Error;
 use std::fmt;
 
-/// Errors that can occur during the lexing process.
+/// An Error that occurs during the lexing process.
 /// Serves as the interface between a lexer and its user.
 #[derive(Debug, PartialEq)]
-pub enum LexError {
-    /// An illegal char, not in the syntax.
-    IllegalChar { cause: String, location: Range },
-    /// An illegal number literal, such as `12.`.
-    IllegalNumLiteral { cause: String, location: Range },
-    /// An internal error impossible to occur if lexed as expected.
-    Unexpected { cause: String, location: Range },
+pub struct LexError {
+    pub kind: LexErrorKind,
+    pub reason: LexErrorReason,
 }
 
-macro_rules! write_lex_err {
-    ($fmt:ident, $reason:literal, $cause:ident, $loc: ident) => {
-        write!($fmt, "Reason: {}, Cause: '{}', Location: {:?}", $reason, $cause, $loc)
-    };
+/// Kinds of errors due to the lexing.
+#[derive(Debug, PartialEq)]
+pub enum LexErrorKind {
+    /// An illegal char, not in the syntax.
+    IllegalChar,
+    /// An illegal number literal, such as `12.`.
+    IllegalNumLiteral,
+    /// An internal error impossible to occur if lexed as expected.
+    Unexpected,
+}
+
+/// Reason of the error, with the string `cause` and its location `location` in the source.
+#[derive(Debug, PartialEq)]
+pub struct LexErrorReason {
+    pub cause: String,
+    pub location: Range,
+}
+
+impl LexError {
+    pub fn new(kind: LexErrorKind, cause: String, location: Range) -> Self {
+        Self { kind, reason: LexErrorReason::new(cause, location) }
+    }
+}
+
+impl LexErrorReason {
+    pub fn new(cause: String, location: Range) -> Self {
+        Self { cause, location }
+    }
 }
 
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            LexError::IllegalChar { cause: c, location: l } => write_lex_err!(f, "LEX_ILLEGAL_CHAR", c, l),
-            LexError::IllegalNumLiteral { cause: c, location: l } => write_lex_err!(f, "LEX_ILLEGAL_NUM_LITERAL", c, l),
-            LexError::Unexpected { cause: c, location: l } => write_lex_err!(f, "LEX_UNEXPECTED", c, l),
-        }
+        write!(
+            f,
+            "Reason: '{}', Cause: {}, Location: {:?}",
+            self.kind, self.reason.cause, self.reason.location
+        )
+    }
+}
+
+impl fmt::Display for LexErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            LexErrorKind::IllegalChar => "IllegalChar",
+            LexErrorKind::IllegalNumLiteral => "IllegalNumLiteral",
+            LexErrorKind::Unexpected => "Unexpected",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -22,12 +22,12 @@ struct Lexer<'a> {
 }
 
 macro_rules! advance_and_lex {
-    ($self:ident, $lex_fn:expr) => {{
+    ($self:ident, $lex_fn:expr $(,)?) => {{
         let first_location = $self.scanner.locate();
         $self.scanner.advance();
         $lex_fn($self, first_location)
     }};
-    ($self:ident, $lex_fn:expr, $first_char:expr) => {{
+    ($self:ident, $lex_fn:expr, $first_char:expr $(,)?) => {{
         let first_location = $self.scanner.locate();
         $self.scanner.advance();
         $lex_fn($self, first_location, $first_char)
@@ -201,7 +201,7 @@ mod tests {
     /// Asserts a given literal to be lexed into the expected tokens.
     /// Helps write a test more declaratively.
     macro_rules! assert_lex {
-        ($source:literal, $expected:expr) => {
+        ($source:literal, $expected:expr $(,)?) => {
             assert_eq!(
                 lex($source)?,
                 $expected,
@@ -215,7 +215,7 @@ mod tests {
     /// Asserts lexing a given literal will fail.
     /// Helps write a test more declaratively.
     macro_rules! assert_lex_fail {
-        ($source:literal, $expected:expr) => {
+        ($source:literal, $expected:expr $(,)?) => {
             assert_eq!(
                 lex($source),
                 Err($expected),
@@ -270,7 +270,7 @@ mod tests {
             fn test_without_decimal() -> Res {
                 assert_lex!(
                     "123",
-                    vec![mktoken!(TokenKind::Number(123.0), loc 0, 0, 0, "123".len())]
+                    vec![mktoken!(TokenKind::Number(123.0), loc 0, 0, 0, "123".len())],
                 );
             }
 
@@ -278,7 +278,7 @@ mod tests {
             fn test_with_decimal() -> Res {
                 assert_lex!(
                     "12.25",
-                    vec![mktoken!(TokenKind::Number(12.25), loc 0, 0, 0, "12.25".len())]
+                    vec![mktoken!(TokenKind::Number(12.25), loc 0, 0, 0, "12.25".len())],
                 );
             }
         }
@@ -290,7 +290,7 @@ mod tests {
             fn test_illegal() -> Res {
                 assert_lex_fail!(
                     "12^",
-                    LexError::new(LexErrorKind::IllegalChar, "^".to_string(), Range::from_nums(0, 2, 0, 3),)
+                    LexError::new(LexErrorKind::IllegalChar, "^".to_string(), Range::from_nums(0, 2, 0, 3)),
                 );
             }
 
@@ -298,7 +298,7 @@ mod tests {
             fn test_beginning_with_dot() -> Res {
                 assert_lex_fail!(
                     ".25",
-                    LexError::new(LexErrorKind::IllegalChar, ".".to_string(), Range::from_nums(0, 0, 0, 1),)
+                    LexError::new(LexErrorKind::IllegalChar, ".".to_string(), Range::from_nums(0, 0, 0, 1)),
                 );
             }
 
@@ -310,7 +310,7 @@ mod tests {
                         LexErrorKind::IllegalNumLiteral,
                         "12.".to_string(),
                         Range::from_nums(0, 0, 0, 3),
-                    )
+                    ),
                 );
             }
 
@@ -322,7 +322,7 @@ mod tests {
                         LexErrorKind::IllegalNumLiteral,
                         "12..".to_string(),
                         Range::from_nums(0, 0, 0, 4),
-                    )
+                    ),
                 );
             }
 
@@ -334,7 +334,7 @@ mod tests {
                         LexErrorKind::IllegalNumLiteral,
                         "12.^".to_string(),
                         Range::from_nums(0, 0, 0, 4),
-                    )
+                    ),
                 );
             }
         }
@@ -380,7 +380,7 @@ mod tests {
                     mktoken!(TokenKind::Number(12.0), loc 0, 0, 0, "12".len()),
                     mktoken!(TokenKind::Plus, loc 0, "12 ".len(), 0, "12 +".len()),
                     mktoken!(TokenKind::Number(34.675), loc 0, "12 + ".len(), 0, "12 + 34.675".len()),
-                ]
+                ],
             );
         }
 
@@ -392,7 +392,7 @@ mod tests {
                 vec![
                     mktoken!(TokenKind::Plus, loc 0, 0, 0, "+".len()),
                     mktoken!(TokenKind::Plus, loc 0, "+ ".len(), 0, "+ +".len()),
-                ]
+                ],
             );
         }
     }
@@ -404,7 +404,7 @@ mod tests {
         fn test_unrecognizable() -> Res {
             assert_lex_fail!(
                 "^",
-                LexError::new(LexErrorKind::IllegalChar, "^".to_string(), Range::from_nums(0, 0, 0, 1),)
+                LexError::new(LexErrorKind::IllegalChar, "^".to_string(), Range::from_nums(0, 0, 0, 1)),
             );
         }
     }

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -315,6 +315,18 @@ mod tests {
             }
 
             #[test]
+            fn test_two_dots_decimal() -> Res {
+                assert_lex_fail!(
+                    "12..",
+                    LexError::new(
+                        LexErrorKind::IllegalNumLiteral,
+                        "12..".to_string(),
+                        Range::from_nums(0, 0, 0, 4),
+                    )
+                );
+            }
+
+            #[test]
             fn test_illegal_decimal() -> Res {
                 assert_lex_fail!(
                     "12.^",

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -124,7 +124,7 @@ impl<'a> Lexer<'a> {
             Some(s) if string::is_digit(s) => (),
             other => {
                 let cause = format!("{}{}", lexeme, other.unwrap_or(""));
-                let location = Range::new(begin, self.scanner.locate().begin);
+                let location = Range::new(begin, self.scanner.locate().end);
                 return Err(LexError::new(LexErrorKind::IllegalNumLiteral, cause, location));
             }
         }
@@ -287,6 +287,14 @@ mod tests {
             use super::*;
 
             #[test]
+            fn test_illegal() -> Res {
+                assert_lex_fail!(
+                    "12^",
+                    LexError::new(LexErrorKind::IllegalChar, "^".to_string(), Range::from_nums(0, 2, 0, 3),)
+                );
+            }
+
+            #[test]
             fn test_beginning_with_dot() -> Res {
                 assert_lex_fail!(
                     ".25",
@@ -302,6 +310,18 @@ mod tests {
                         LexErrorKind::IllegalNumLiteral,
                         "12.".to_string(),
                         Range::from_nums(0, 0, 0, 3),
+                    )
+                );
+            }
+
+            #[test]
+            fn test_illegal_decimal() -> Res {
+                assert_lex_fail!(
+                    "12.^",
+                    LexError::new(
+                        LexErrorKind::IllegalNumLiteral,
+                        "12.^".to_string(),
+                        Range::from_nums(0, 0, 0, 4),
                     )
                 );
             }

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -383,6 +383,18 @@ mod tests {
                 ]
             );
         }
+
+        /// Should not fail, since the lexer does not know the syntax.
+        #[test]
+        fn test_two_pluses() -> Res {
+            assert_lex!(
+                "+ +",
+                vec![
+                    mktoken!(TokenKind::Plus, loc 0, 0, 0, "+".len()),
+                    mktoken!(TokenKind::Plus, loc 0, "+ ".len(), 0, "+ +".len()),
+                ]
+            );
+        }
     }
 
     mod illegal {

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -85,40 +85,6 @@ impl<'a> Lexer<'a> {
         Ok(tokens)
     }
 
-    fn skip_comment(&mut self) -> () {
-        loop {
-            match self.scanner.read() {
-                Some("\n") | Some("\r") | Some("\r\n") | None => {
-                    self.scanner.advance();
-                    break;
-                }
-                _ => {
-                    self.scanner.advance();
-                }
-            }
-        }
-    }
-
-    fn lex_plus(&mut self, first_location: Range) -> ResToken {
-        Ok(Token::from_plus(first_location))
-    }
-
-    fn lex_minus(&mut self, first_location: Range) -> ResToken {
-        Ok(Token::from_minus(first_location))
-    }
-
-    fn lex_asterisk(&mut self, first_location: Range) -> ResToken {
-        Ok(Token::from_asterisk(first_location))
-    }
-
-    fn lex_slash(&mut self, first_location: Range) -> ResToken {
-        Ok(Token::from_slash(first_location))
-    }
-
-    fn lex_percent(&mut self, first_location: Range) -> ResToken {
-        Ok(Token::from_percent(first_location))
-    }
-
     fn lex_num(&mut self, first_location: Range, first_char: &'a str) -> ResToken {
         let mut lexeme = first_char.to_string();
         let begin = first_location.begin;
@@ -165,6 +131,40 @@ impl<'a> Lexer<'a> {
 
         let token = Token::from_num(num, Range::new(begin, end));
         return Ok(token);
+    }
+
+    fn lex_plus(&mut self, first_location: Range) -> ResToken {
+        Ok(Token::from_plus(first_location))
+    }
+
+    fn lex_minus(&mut self, first_location: Range) -> ResToken {
+        Ok(Token::from_minus(first_location))
+    }
+
+    fn lex_asterisk(&mut self, first_location: Range) -> ResToken {
+        Ok(Token::from_asterisk(first_location))
+    }
+
+    fn lex_slash(&mut self, first_location: Range) -> ResToken {
+        Ok(Token::from_slash(first_location))
+    }
+
+    fn lex_percent(&mut self, first_location: Range) -> ResToken {
+        Ok(Token::from_percent(first_location))
+    }
+
+    fn skip_comment(&mut self) -> () {
+        loop {
+            match self.scanner.read() {
+                Some("\n") | Some("\r") | Some("\r\n") | None => {
+                    self.scanner.advance();
+                    break;
+                }
+                _ => {
+                    self.scanner.advance();
+                }
+            }
+        }
     }
 }
 

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -74,7 +74,7 @@ impl<'a> Lexer<'a> {
                 }
                 Some(s) if string::is_whitespace(s) => self.scanner.advance(),
                 Some(x) => {
-                    return Err(LexError::IllegalChar { char: x.to_string(), location: self.scanner.locate() });
+                    return Err(LexError::IllegalChar { cause: x.to_string(), location: self.scanner.locate() });
                 }
                 None => {
                     break;
@@ -119,9 +119,9 @@ impl<'a> Lexer<'a> {
         match self.scanner.read() {
             Some(s) if string::is_digit(s) => (),
             other => {
-                let bad_literal = format!("{}{}", lexeme, other.unwrap_or(""));
+                let cause = format!("{}{}", lexeme, other.unwrap_or(""));
                 let location = Range::new(begin, self.scanner.locate().begin);
-                return Err(LexError::IllegalNumLiteral { bad_literal, location });
+                return Err(LexError::IllegalNumLiteral { cause, location });
             }
         }
 
@@ -328,7 +328,7 @@ mod tests {
             assert_lex_fail!(
                 "^",
                 LexError::IllegalChar {
-                    char: "^".to_string(),
+                    cause: "^".to_string(),
                     location: Range::from_nums(0, 0, 0, 1),
                 }
             );
@@ -339,7 +339,7 @@ mod tests {
             assert_lex_fail!(
                 ".25",
                 LexError::IllegalChar {
-                    char: ".".to_string(),
+                    cause: ".".to_string(),
                     location: Range::from_nums(0, 0, 0, 1)
                 }
             );
@@ -350,7 +350,7 @@ mod tests {
             assert_lex_fail!(
                 "12.",
                 LexError::IllegalNumLiteral {
-                    bad_literal: "12.".to_string(),
+                    cause: "12.".to_string(),
                     location: Range::from_nums(0, 0, 0, "12.".len() as u64)
                 }
             );

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -230,32 +230,32 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_lex_empty() -> Res {
+        fn test_empty() -> Res {
             assert_lex!("", vec![]);
         }
 
         #[test]
-        fn test_lex_whitespaces() -> Res {
+        fn test_whitespaces() -> Res {
             assert_lex!("   ", vec![]);
         }
 
         #[test]
-        fn test_lex_tabs() -> Res {
+        fn test_tabs() -> Res {
             assert_lex!("\t\t", vec![]);
         }
 
         #[test]
-        fn test_lex_new_lines() -> Res {
+        fn test_new_lines() -> Res {
             assert_lex!("\n\n\r\r\r\n\r\n", vec![]);
         }
 
         #[test]
-        fn test_lex_comment() -> Res {
+        fn test_comment() -> Res {
             assert_lex!("# comment", vec![]);
         }
 
         #[test]
-        fn test_lex_multi_line_comment() -> Res {
+        fn test_multi_line_comment() -> Res {
             assert_lex!("# comment line 1\r\n# comment line 2", vec![]);
         }
     }
@@ -263,20 +263,48 @@ mod tests {
     mod num {
         use super::*;
 
-        #[test]
-        fn test_lex_without_decimal() -> Res {
-            assert_lex!(
-                "123",
-                vec![mktoken!(TokenKind::Number(123.0), loc 0, 0, 0, "123".len())]
-            );
+        mod success {
+            use super::*;
+
+            #[test]
+            fn test_without_decimal() -> Res {
+                assert_lex!(
+                    "123",
+                    vec![mktoken!(TokenKind::Number(123.0), loc 0, 0, 0, "123".len())]
+                );
+            }
+
+            #[test]
+            fn test_with_decimal() -> Res {
+                assert_lex!(
+                    "12.25",
+                    vec![mktoken!(TokenKind::Number(12.25), loc 0, 0, 0, "12.25".len())]
+                );
+            }
         }
 
-        #[test]
-        fn test_lex_with_decimal() -> Res {
-            assert_lex!(
-                "12.25",
-                vec![mktoken!(TokenKind::Number(12.25), loc 0, 0, 0, "12.25".len())]
-            );
+        mod fail {
+            use super::*;
+
+            #[test]
+            fn test_beginning_with_dot() -> Res {
+                assert_lex_fail!(
+                    ".25",
+                    LexError::new(LexErrorKind::IllegalChar, ".".to_string(), Range::from_nums(0, 0, 0, 1),)
+                );
+            }
+
+            #[test]
+            fn test_ending_with_dot() -> Res {
+                assert_lex_fail!(
+                    "12.",
+                    LexError::new(
+                        LexErrorKind::IllegalNumLiteral,
+                        "12.".to_string(),
+                        Range::from_nums(0, 0, 0, 3),
+                    )
+                );
+            }
         }
     }
 
@@ -284,27 +312,27 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_lex_plus() -> Res {
+        fn test_plus() -> Res {
             assert_lex!("+", vec![mktoken!(TokenKind::Plus, loc 0, 0, 0, 1)]);
         }
 
         #[test]
-        fn test_lex_minus() -> Res {
+        fn test_minus() -> Res {
             assert_lex!("-", vec![mktoken!(TokenKind::Minus, loc 0, 0, 0, 1)]);
         }
 
         #[test]
-        fn test_lex_asterisk() -> Res {
+        fn test_asterisk() -> Res {
             assert_lex!("*", vec![mktoken!(TokenKind::Asterisk, loc 0, 0, 0, 1)]);
         }
 
         #[test]
-        fn test_lex_slash() -> Res {
+        fn test_slash() -> Res {
             assert_lex!("/", vec![mktoken!(TokenKind::Slash, loc 0, 0, 0, 1)]);
         }
 
         #[test]
-        fn test_lex_percent() -> Res {
+        fn test_percent() -> Res {
             assert_lex!("%", vec![mktoken!(TokenKind::Percent, loc 0, 0, 0, 1)]);
         }
     }
@@ -313,7 +341,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_lex() -> Res {
+        fn test_addition() -> Res {
             assert_lex!(
                 "12 + 34.675",
                 vec![
@@ -325,34 +353,14 @@ mod tests {
         }
     }
 
-    mod fail {
+    mod illegal {
         use super::*;
 
         #[test]
-        fn test_illegal_char() -> Res {
+        fn test_unrecognizable() -> Res {
             assert_lex_fail!(
                 "^",
                 LexError::new(LexErrorKind::IllegalChar, "^".to_string(), Range::from_nums(0, 0, 0, 1),)
-            );
-        }
-
-        #[test]
-        fn test_num_beginning_with_dot() -> Res {
-            assert_lex_fail!(
-                ".25",
-                LexError::new(LexErrorKind::IllegalChar, ".".to_string(), Range::from_nums(0, 0, 0, 1),)
-            );
-        }
-
-        #[test]
-        fn test_num_ending_with_dot() -> Res {
-            assert_lex_fail!(
-                "12.",
-                LexError::new(
-                    LexErrorKind::IllegalNumLiteral,
-                    "12.".to_string(),
-                    Range::from_nums(0, 0, 0, 3),
-                )
             );
         }
     }

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -260,7 +260,7 @@ mod tests {
         }
     }
 
-    mod num {
+    mod num_literals {
         use super::*;
 
         mod success {
@@ -369,11 +369,11 @@ mod tests {
         }
     }
 
-    mod expression {
+    mod multi_chars {
         use super::*;
 
         #[test]
-        fn test_addition() -> Res {
+        fn test_addition_expression() -> Res {
             assert_lex!(
                 "12 + 34.675",
                 vec![

--- a/komi_lexer/src/source_scanner/mod.rs
+++ b/komi_lexer/src/source_scanner/mod.rs
@@ -50,7 +50,10 @@ impl<'a> Scanner for SourceScanner<'a> {
     }
 
     fn locate(&self) -> Range {
-        Range::from_nums(self.row, self.col, self.row, self.col + 1)
+        match self.read() {
+            None => Range::from_nums(self.row, self.col, self.row, self.col),
+            _ => Range::from_nums(self.row, self.col, self.row, self.col + 1),
+        }
     }
 }
 
@@ -146,10 +149,10 @@ mod tests {
         assert_eq!(scanner.locate(), Range::from_nums(0, 1, 0, 2),);
         scanner.advance();
         assert_eq!(scanner.read(), None);
-        assert_eq!(scanner.locate(), Range::from_nums(0, 2, 0, 3),);
+        assert_eq!(scanner.locate(), Range::from_nums(0, 2, 0, 2),);
         scanner.advance();
         assert_eq!(scanner.read(), None);
-        assert_eq!(scanner.locate(), Range::from_nums(0, 2, 0, 3),);
+        assert_eq!(scanner.locate(), Range::from_nums(0, 2, 0, 2),);
     }
 
     #[test]
@@ -167,10 +170,10 @@ mod tests {
         assert_eq!(scanner.locate(), Range::from_nums(2, 0, 2, 1),);
         scanner.advance();
         assert_eq!(scanner.read(), None);
-        assert_eq!(scanner.locate(), Range::from_nums(3, 0, 3, 1),);
+        assert_eq!(scanner.locate(), Range::from_nums(3, 0, 3, 0),);
         scanner.advance();
         assert_eq!(scanner.read(), None);
-        assert_eq!(scanner.locate(), Range::from_nums(3, 0, 3, 1),);
+        assert_eq!(scanner.locate(), Range::from_nums(3, 0, 3, 0),);
     }
 
     #[test]

--- a/komi_lexer/src/source_scanner/mod.rs
+++ b/komi_lexer/src/source_scanner/mod.rs
@@ -18,6 +18,8 @@ impl<'a> SourceScanner<'a> {
 impl<'a> Scanner for SourceScanner<'a> {
     type Item = Option<&'a str>;
 
+    /// Reads next character unit.
+    /// Note that if CRLF (`"\r\n"`) encountered, returned as a unit.
     fn read(&self) -> Option<&'a str> {
         match self.tape.get_current() {
             Some("\r") => match self.tape.peek_next() {
@@ -28,6 +30,7 @@ impl<'a> Scanner for SourceScanner<'a> {
         }
     }
 
+    /// Moves the internal pointer to the next unit.
     fn advance(&mut self) -> () {
         match self.read() {
             Some("\r") | Some("\n") => {
@@ -49,6 +52,8 @@ impl<'a> Scanner for SourceScanner<'a> {
         }
     }
 
+    /// Returns the current location, which is specific by `begin` and `end` as a half-open interval `[begin, end)`.
+    /// Note that an empty interval returned if the end of the source.
     fn locate(&self) -> Range {
         match self.read() {
             None => Range::from_nums(self.row, self.col, self.row, self.col),

--- a/komi_util/src/location/range/mod.rs
+++ b/komi_util/src/location/range/mod.rs
@@ -8,6 +8,8 @@ pub struct Range {
     pub end: Spot,
 }
 
+// TODO: json-compatible or more concise format on write!()?
+
 impl Range {
     pub const fn new(begin: Spot, end: Spot) -> Self {
         Range { begin, end }

--- a/komi_util/src/location/spot/mod.rs
+++ b/komi_util/src/location/spot/mod.rs
@@ -5,6 +5,8 @@ pub struct Spot {
     col: u64,
 }
 
+// TODO: json-compatible or more concise format on write!()?
+
 impl Spot {
     pub const fn new(row: u64, col: u64) -> Self {
         Spot { row, col }


### PR DESCRIPTION
recognize number literals beginning or ending with dot as illegal literals

(extra) refactor:
- redesign lexer error system, to make each variant have consistent struct