### PR TITLE
fix publishing action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   cd:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: checkout
@@ -24,4 +21,4 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 22.15.1
           registry-url: https://npm.pkg.github.com
           scope: "@wcho21"
+      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wcho21/komi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wcho21/komi",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "komi": "file:./dist/",
         "vite": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "files": [
     "./dist/*"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wcho21/komi.git"
+  },
   "devDependencies": {
     "komi": "file:./dist/",
     "vite": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/wcho21/komi.git"
   },
+  "publishConfig": {
+    "@wcho21:registry": "https://npm.pkg.github.com"
+  },
   "devDependencies": {
     "komi": "file:./dist/",
     "vite": "6.3.5",


### PR DESCRIPTION
the [github action documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) says

> You can use the permissions key in your workflow file to modify permissions for the GITHUB_TOKEN for an entire workflow or for individual jobs.

which means I can change permissions of the `GITHUB_TOKEN`, which is given every github action by default, but it seems not and the action kept failing

the issue is resolved with the manually created token with `package:write` access