### PR TITLE
build as bundler package

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -18,10 +18,8 @@ fail() {
 build() {
   cd komi_wasm
 
-  # avoid using '--target bundler' due to limited support in modern bundlers
-  # for example, 'bun' doesn't support it at all, and 'vite' can include it via 'vite-plugin-wasm' plugin, it doesn't work with 'vitest'
-  # see https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#bundlers
-  wasm-pack build --target web ${BUILD_MODE} --out-name ${WASM_OUT_NAME} --scope ${WASM_OUT_SCOPE}
+  # build as bundled library
+  wasm-pack build --target bundler ${BUILD_MODE} --out-name ${WASM_OUT_NAME} --scope ${WASM_OUT_SCOPE}
 
   if [ $? -ne 0 ]; then
     fail


### PR DESCRIPTION
note on why determined to build with bundler target:
- web target build artifact is supposed to be used with `<script>` tag, but in modern frontend frameworks we usually import script with `import`. to import the artifact, we need to use dynamic import like `await import("https://path/to/script.js")`, but the bundler (like `vite`) in framework cannot find `wasm` file as a static asset, and moreover typescript language server can't infer the types.