### PR TITLE
throw error to javascript layer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,9 +4,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 RUN apt-get update && apt-get --yes install git vim gnupg2 curl unzip build-essential && apt-get clean
 
+# install rust toolchain
 ARG RUSTUP_VERSION=1.28.2
 ARG RUST_VERSION=1.86.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain ${RUST_VERSION} -y
 ARG WASM_PACK_VERSION=0.13.1
 ARG JUST_VERSION=1.40.0
 RUN PATH="/root/.cargo/bin:${PATH}" cargo install wasm-pack@${WASM_PACK_VERSION} just@${JUST_VERSION}
+
+# install node, required by integration test
+ARG NVM_VERSION=0.40.3
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
+ARG NODE_VERSION=22.15.1
+RUN /bin/bash -c "source /root/.nvm/nvm.sh && nvm install ${NODE_VERSION}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,9 @@ name = "komi_wasm"
 version = "0.1.0-beta1"
 dependencies = [
  "const_format",
+ "js-sys",
  "komi",
+ "komi_util",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/komi_lexer/src/source_scanner/mod.rs
+++ b/komi_lexer/src/source_scanner/mod.rs
@@ -5,8 +5,8 @@ use komi_util::{Range, Scanner, Tape};
 /// It reads characters one by one, but treats CRLF ("\r\n") as a single character.
 pub struct SourceScanner<'a> {
     tape: Utf8Tape<'a>,
-    col: u64,
-    row: u64,
+    col: u32,
+    row: u32,
 }
 
 impl<'a> SourceScanner<'a> {

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -95,19 +95,19 @@ macro_rules! mkast {
     (prog loc $br:expr, $bc:expr, $er:expr, $ec: expr, $exprs:expr) => {
         Box::new(Ast::new(
             AstKind::Program { expressions: $exprs },
-            Range::from_nums($br as u64, $bc as u64, $er as u64, $ec as u64),
+            Range::from_nums($br as u32, $bc as u32, $er as u32, $ec as u32),
         ))
     };
     (prefix $kind:ident, loc $br:expr, $bc:expr, $er:expr, $ec: expr, operand $oprnd:expr $(,)?) => {
         Box::new(Ast::new(
             AstKind::$kind { operand: $oprnd },
-            Range::from_nums($br as u64, $bc as u64, $er as u64, $ec as u64),
+            Range::from_nums($br as u32, $bc as u32, $er as u32, $ec as u32),
         ))
     };
     (infix $kind:ident, loc $br:expr, $bc:expr, $er:expr, $ec: expr, left $left:expr, right $right:expr $(,)?) => {
         Box::new(Ast::new(
             AstKind::$kind { left: $left, right: $right },
-            Range::from_nums($br as u64, $bc as u64, $er as u64, $ec as u64),
+            Range::from_nums($br as u32, $bc as u32, $er as u32, $ec as u32),
         ))
     };
     (num $val:expr, loc $br:expr, $bc:expr, $er:expr, $ec: expr) => {

--- a/komi_syntax/src/token/mod.rs
+++ b/komi_syntax/src/token/mod.rs
@@ -71,7 +71,7 @@ impl Token {
 #[macro_export]
 macro_rules! mktoken {
     ($kind:expr, loc $br:expr, $bc:expr, $er:expr, $ec:expr) => {
-        Token::new($kind, Range::from_nums($br as u64, $bc as u64, $er as u64, $ec as u64))
+        Token::new($kind, Range::from_nums($br as u32, $bc as u32, $er as u32, $ec as u32))
     };
 }
 

--- a/komi_util/src/lib.rs
+++ b/komi_util/src/lib.rs
@@ -3,6 +3,7 @@ pub mod location;
 pub mod scanner;
 pub mod string;
 pub mod tape;
+pub mod unpacker;
 
 pub use error::EngineError;
 pub use location::range;

--- a/komi_util/src/location/range/mod.rs
+++ b/komi_util/src/location/range/mod.rs
@@ -15,7 +15,7 @@ impl Range {
         Range { begin, end }
     }
 
-    pub const fn from_nums(begin_row: u64, begin_col: u64, end_row: u64, end_col: u64) -> Self {
+    pub const fn from_nums(begin_row: u32, begin_col: u32, end_row: u32, end_col: u32) -> Self {
         let begin = Spot::new(begin_row, begin_col);
         let end = Spot::new(end_row, end_col);
 

--- a/komi_util/src/location/spot/mod.rs
+++ b/komi_util/src/location/spot/mod.rs
@@ -1,14 +1,14 @@
 /// A position representing the coordinate of a character in multi-line text.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Spot {
-    row: u64,
-    col: u64,
+    pub row: u32,
+    pub col: u32,
 }
 
 // TODO: json-compatible or more concise format on write!()?
 
 impl Spot {
-    pub const fn new(row: u64, col: u64) -> Self {
+    pub const fn new(row: u32, col: u32) -> Self {
         Spot { row, col }
     }
 }

--- a/komi_util/src/unpacker/mod.rs
+++ b/komi_util/src/unpacker/mod.rs
@@ -1,0 +1,45 @@
+use crate::{EngineError, Range, Spot};
+
+/// Returns `(spot.row, spot.col)` from the `spot`.
+pub fn unpack_spot(spot: &Spot) -> (u32, u32) {
+    (spot.row, spot.col)
+}
+
+/// Returns `(&err.kind, &err.location)` from the `err`.
+pub fn unpack_engine_error<T>(err: &EngineError<T>) -> (&T, &Range) {
+    (&err.kind, &err.location)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod unpack_spot {
+        use super::*;
+
+        #[test]
+        fn test() {
+            let spot = Spot::new(1, 2);
+
+            let (row, col) = unpack_spot(&spot);
+
+            assert_eq!(row, 1);
+            assert_eq!(col, 2);
+        }
+    }
+
+    mod unpack_engine_error {
+        use super::*;
+
+        #[test]
+        fn test() {
+            let error_kind = "foo";
+            let error = EngineError::new(error_kind, Range::from_nums(1, 2, 3, 4));
+
+            let (kind, location) = unpack_engine_error(&error);
+
+            assert_eq!(*kind, error_kind);
+            assert_eq!(*location, Range::from_nums(1, 2, 3, 4));
+        }
+    }
+}

--- a/komi_wasm/Cargo.toml
+++ b/komi_wasm/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 wasm-bindgen = "0.2.100"
 const_format = "0.2.34"
 komi = { path = "../komi" }
+komi_util = { path = "../komi_util" }
+js-sys = "0.3.77"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"

--- a/komi_wasm/src/lib.rs
+++ b/komi_wasm/src/lib.rs
@@ -1,12 +1,18 @@
-mod util;
+pub mod util;
 
 use util::exec_fmt::format;
-
+use util::res_converter::convert;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+#[deprecated]
 pub fn execute(source: &str) -> String {
     format(komi::execute(source))
+}
+
+#[wasm_bindgen]
+pub fn get_execution_result(source: &str) -> Result<JsValue, JsValue> {
+    convert(&komi::execute(source))
 }
 
 #[cfg(test)]

--- a/komi_wasm/src/util/js_val/mod.rs
+++ b/komi_wasm/src/util/js_val/mod.rs
@@ -1,0 +1,50 @@
+use js_sys::{Error, JsString, Number, Object, Reflect};
+use komi_util::unpacker::unpack_spot;
+use komi_util::{Range, Spot};
+use wasm_bindgen::JsValue;
+
+pub fn set_uint_property(obj: &Object, key: &str, value: u32) -> Result<bool, JsValue> {
+    Reflect::set(obj, &JsString::from(key), &Number::from(value))
+}
+
+pub fn set_object_property(obj: &Object, key: &str, value: &Object) -> Result<bool, JsValue> {
+    Reflect::set(obj, &JsString::from(key), value)
+}
+
+pub fn get_property(obj: &JsValue, key: &str) -> Result<JsValue, JsValue> {
+    Reflect::get(obj, &JsString::from(key))
+}
+
+pub fn convert_spot_to_js_object(spot: &Spot) -> Result<Object, JsValue> {
+    let obj = Object::new();
+    let (row, col) = unpack_spot(spot);
+
+    set_uint_property(&obj, "row", row)?;
+    set_uint_property(&obj, "col", col)?;
+
+    Ok(obj)
+}
+
+pub fn convert_range_to_js_object(location: &Range) -> Result<Object, JsValue> {
+    let obj = Object::new();
+
+    let begin = convert_spot_to_js_object(&location.begin)?;
+    let end = convert_spot_to_js_object(&location.end)?;
+
+    set_object_property(&obj, "begin", &begin)?;
+    set_object_property(&obj, "end", &end)?;
+
+    Ok(obj)
+}
+
+pub fn make_js_err(name: &str, message: &str, location: &JsValue) -> Error {
+    let js_err = Error::new(message);
+
+    js_err.set_name(name);
+
+    let cause = Object::new();
+    let _ = Reflect::set(&cause, &JsString::from("location"), &location);
+    js_err.set_cause(&cause);
+
+    js_err
+}

--- a/komi_wasm/src/util/mod.rs
+++ b/komi_wasm/src/util/mod.rs
@@ -1,1 +1,2 @@
 pub mod exec_fmt;
+pub mod js_val;

--- a/komi_wasm/src/util/mod.rs
+++ b/komi_wasm/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod exec_fmt;
 pub mod js_val;
+pub mod res_converter;

--- a/komi_wasm/src/util/res_converter/mod.rs
+++ b/komi_wasm/src/util/res_converter/mod.rs
@@ -1,0 +1,35 @@
+use crate::util::js_val::{convert_range_to_js_object, make_js_err};
+use js_sys::Error;
+use komi::{ExecError, ExecResult};
+use komi_util::EngineError;
+use komi_util::unpacker::unpack_engine_error;
+use std::fmt::Display;
+use wasm_bindgen::JsValue;
+
+pub fn convert(exec_res: &ExecResult) -> Result<JsValue, JsValue> {
+    match exec_res {
+        Ok(s) => Ok(convert_ok(s)),
+        Err(e) => Err(convert_err(&e)),
+    }
+}
+
+fn convert_ok(ok_str: &str) -> JsValue {
+    JsValue::from_str(ok_str)
+}
+
+fn convert_err(err: &ExecError) -> JsValue {
+    match err {
+        ExecError::Lex(e) => convert_err_to_js_err(e, "LexError").into(),
+        ExecError::Parse(e) => convert_err_to_js_err(e, "ParseError").into(),
+        ExecError::Eval(e) => convert_err_to_js_err(e, "EvalError").into(),
+    }
+}
+
+fn convert_err_to_js_err<T: Display>(err: &EngineError<T>, name: &str) -> Error {
+    let (kind, location) = unpack_engine_error(&err);
+
+    let message = format!("{}", kind);
+    let cause_location = convert_range_to_js_object(location).unwrap();
+    let js_err = make_js_err(&name, &message, &cause_location);
+    js_err
+}

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -1,9 +1,129 @@
-use komi_wasm::execute;
+use js_sys::{Error, JsString, Number};
+use komi_wasm::get_execution_result;
+use komi_wasm::util::js_val::get_property;
+use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
-#[wasm_bindgen_test]
-fn test_single_number_literal() {
-    let input = "+12.25";
-    let output = execute(input);
-    assert_eq!(output, "komi v1 ok 12.25");
+macro_rules! assert_exec {
+    ($src:expr, $expected:expr) => {
+        let res = get_execution_result($src)?;
+
+        assert_eq!(JsString::from(res), JsString::from($expected));
+    };
+}
+
+macro_rules! assert_error {
+    ($src:expr, $name:expr, $msg:expr, $br:expr, $bc:expr, $er:expr, $ec:expr) => {
+        let res = get_execution_result($src);
+
+        assert!(res.is_err(), "expected an error, but it isn't.");
+
+        let err = Error::from(res.unwrap_err());
+        assert_eq!(
+            err.name(),
+            JsString::from($name),
+            "expected the name (left), but received a different name (right)",
+        );
+        assert_eq!(
+            err.message(),
+            JsString::from($msg),
+            "expected the message (left), but received a different message (right)",
+        );
+
+        let cause = err.cause();
+        let location = get_property(&cause, "location")?;
+        let begin = get_property(&location, "begin")?;
+        let end = get_property(&location, "end")?;
+
+        let begin_row = get_property(&begin, "row")?;
+        let begin_col = get_property(&begin, "col")?;
+        let end_row = get_property(&end, "row")?;
+        let end_col = get_property(&end, "col")?;
+
+        assert_eq!(
+            Number::from(begin_row),
+            Number::from($br as u32),
+            "expected the begin_row (left), but received a different number (right)"
+        );
+        assert_eq!(
+            Number::from(begin_col),
+            Number::from($bc as u32),
+            "expected the begin_col (left), but received a different number (right)"
+        );
+        assert_eq!(
+            Number::from(end_row),
+            Number::from($er as u32),
+            "expected the end_row (left), but received a different number (right)"
+        );
+        assert_eq!(
+            Number::from(end_col),
+            Number::from($ec as u32),
+            "expected the end_col (left), but received a different number (right)"
+        );
+    };
+}
+
+mod tests {
+    use super::*;
+
+    mod ok {
+        use super::*;
+
+        #[wasm_bindgen_test]
+        fn test_single_number_literal() -> Result<(), JsValue> {
+            assert_exec!("12.25", "12.25");
+            Ok(())
+        }
+
+        #[wasm_bindgen_test]
+        fn test_arithmetic_expression() -> Result<(), JsValue> {
+            assert_exec!("(1.5 - 2.5) * 3 / 4 + 5 % 6", "4.25");
+            Ok(())
+        }
+    }
+
+    mod lex_errors {
+        use super::*;
+
+        #[wasm_bindgen_test]
+        fn test_illegal_char() -> Result<(), JsValue> {
+            // "^" is illegal char
+            assert_error!("^", "LexError", "IllegalChar", 0, 0, 0, "^".len());
+            Ok(())
+        }
+
+        #[wasm_bindgen_test]
+        fn test_illegal_num_literal() -> Result<(), JsValue> {
+            assert_error!("12.", "LexError", "IllegalNumLiteral", 0, 0, 0, "12.".len());
+            Ok(())
+        }
+    }
+
+    mod parse_errors {
+        use super::*;
+
+        #[wasm_bindgen_test]
+        fn test_invalid_expr_start() -> Result<(), JsValue> {
+            assert_error!("*", "ParseError", "InvalidExprStart", 0, 0, 0, "*".len());
+            Ok(())
+        }
+
+        #[wasm_bindgen_test]
+        fn test_lparen_not_closed() -> Result<(), JsValue> {
+            assert_error!("(12+3", "ParseError", "LParenNotClosed", 0, 0, 0, "(12+3".len());
+            Ok(())
+        }
+
+        #[wasm_bindgen_test]
+        fn test_no_infix_right_operand() -> Result<(), JsValue> {
+            assert_error!("1+", "ParseError", "NoInfixRightOperand", 0, 0, 0, "1+".len());
+            Ok(())
+        }
+
+        #[wasm_bindgen_test]
+        fn test_no_prefix_operand() -> Result<(), JsValue> {
+            assert_error!("+", "ParseError", "NoPrefixOperand", 0, 0, 0, "+".len());
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
feat:
- `get_execution_result()` throws errors to javascript layer if an error occurs while execution. this exposes preferable error interface to javascript, rather than returning string on error. (now string value version `execute()` is marked deprecated.)

(internal) feat:
- add internal utils to shorten codes when handling `js-sys` and `JsValue`.

refactor:
- change location number type from `u64` to `u32`, to make it compatible with `js-sys`. note that `Number::from()` supports up to `u32`, as described in the [documentation](https://rustwasm.github.io/wasm-bindgen/api/js_sys/struct.Number.html#impl-From%3Cu32%3E-for-Number).

(extra) chore:
- install node.js in dev container
  - really important, because the integration test using `wasm-pack test --node` works only if the node is installed.