### PR TITLE
support connectives

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -123,6 +123,14 @@ mod tests {
         "!",
         ExecError::Parse(ParseError::new(ParseErrorKind::NoPrefixOperand, Range::from_nums(0, 0, 0, 1)))
     )]
+    #[case::conjunction(
+        "그리고",
+        ExecError::Parse(ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 3)))
+    )]
+    #[case::disjunction(
+        "또는",
+        ExecError::Parse(ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2)))
+    )]
     #[case::dot(
         ".",
         ExecError::Lex(LexError::new(LexErrorKind::IllegalChar, Range::from_nums(0, 0, 0, 1)))
@@ -165,7 +173,7 @@ mod tests {
     #[rstest]
     #[case::five_kinds("9 * 8 % 7 - 6 + 5 / 4", "-2.75")]
     #[case::grouping("16 - (8 - (4 - 2))", "10")]
-    fn arithmetic_compound(#[case] source: &str, #[case] expected: String) {
+    fn arithmetic_infix_compound(#[case] source: &str, #[case] expected: String) {
         assert_exec!(source, expected);
     }
 
@@ -223,6 +231,26 @@ mod tests {
     )]
     fn illegal_two_arithmetic_infixes(#[case] source: &str, #[case] error: ExecError) {
         assert_exec_fail!(source, error);
+    }
+
+    #[rstest]
+    #[case::conjunction("참 그리고 거짓", "거짓")]
+    #[case::disjunction("참 또는 거짓", "참")]
+    fn connective_infix(#[case] source: &str, #[case] expected: String) {
+        assert_exec!(source, expected);
+    }
+
+    #[rstest]
+    #[case::two_kinds("참 그리고 거짓 또는 참", "참")]
+    #[case::grouping("(참 그리고 거짓) 또는 (참 그리고 (참 그리고 참))", "참")]
+    fn connective_infix_compound(#[case] source: &str, #[case] expected: String) {
+        assert_exec!(source, expected);
+    }
+
+    #[rstest]
+    #[case::three_kinds("!(참 그리고 거짓)", "참")]
+    fn boolean_compount(#[case] source: &str, #[case] expected: String) {
+        assert_exec!(source, expected);
     }
 
     #[rstest]

--- a/komi_evaluator/src/err/mod.rs
+++ b/komi_evaluator/src/err/mod.rs
@@ -5,7 +5,8 @@ use std::fmt;
 /// Serves as the interface between a evaluator and its user.
 #[derive(Debug, PartialEq)]
 pub enum EvalErrorKind {
-    InvalidAdditionOperand,
+    InvalidAdditionOperand, // TODO: rename, because it is not only for addition, but for arithmetic infix.
+    InvalidConnectiveInfixOperand,
     InvalidPrefixNumOperand,
     InvalidPrefixBoolOperand,
     Unexpected,
@@ -17,6 +18,7 @@ impl fmt::Display for EvalErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             EvalErrorKind::InvalidAdditionOperand => "InvalidAdditionOperand",
+            EvalErrorKind::InvalidConnectiveInfixOperand => "InvalidConnectiveInfixOperand",
             EvalErrorKind::InvalidPrefixNumOperand => "InvalidPrefixNumOperand",
             EvalErrorKind::InvalidPrefixBoolOperand => "InvalidPrefixBoolOperand",
             EvalErrorKind::Unexpected => "Unexpected",

--- a/komi_evaluator/src/lib.rs
+++ b/komi_evaluator/src/lib.rs
@@ -39,6 +39,7 @@ impl<'a> Evaluator<'a> {
             Ast { kind: AstKind::InfixAsterisk { left, right }, location: _ } => Self::eval_infix_asterisk(left, right),
             Ast { kind: AstKind::InfixSlash { left, right }, location: _ } => Self::eval_infix_slash(left, right),
             Ast { kind: AstKind::InfixPercent { left, right }, location: _ } => Self::eval_infix_percent(left, right),
+            _ => todo!(),
         }
     }
 

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -313,7 +313,7 @@ mod tests {
     #[case::lparen("(", vec![mktoken!(TokenKind::LParen, loc 0, 0, 0, 1)])]
     #[case::rparen(")", vec![mktoken!(TokenKind::RParen, loc 0, 0, 0, 1)])]
     #[case::bang("!", vec![mktoken!(TokenKind::Bang, loc 0, 0, 0, 1)])]
-    fn single_chars(#[case] source: &str, #[case] expected: Vec<Token>) {
+    fn single_token(#[case] source: &str, #[case] expected: Vec<Token>) {
         assert_lex!(source, expected);
     }
 
@@ -328,7 +328,7 @@ mod tests {
         mktoken!(TokenKind::Plus, loc 0, "12 ".len(), 0, "12 +".len()),
         mktoken!(TokenKind::Number(34.675), loc 0, "12 + ".len(), 0, "12 + 34.675".len()),
     ])]
-    fn multiple_chars(#[case] source: &str, #[case] expected: Vec<Token>) {
+    fn multiple_tokens(#[case] source: &str, #[case] expected: Vec<Token>) {
         assert_lex!(source, expected);
     }
 

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -8,7 +8,7 @@ mod source_scanner;
 mod utf8_tape;
 
 pub use err::{LexError, LexErrorKind};
-use komi_syntax::Token;
+use komi_syntax::{Token, TokenKind};
 use komi_util::string;
 use komi_util::{Range, Scanner};
 use source_scanner::SourceScanner;
@@ -86,6 +86,14 @@ impl<'a> Lexer<'a> {
                 }
                 Some("!") => {
                     let token = advance_and_lex!(self, Self::lex_bang)?;
+                    tokens.push(token);
+                }
+                Some("그") => {
+                    let token = advance_and_lex!(self, Self::lex_conjunct)?;
+                    tokens.push(token);
+                }
+                Some("또") => {
+                    let token = advance_and_lex!(self, Self::lex_disjunct)?;
                     tokens.push(token);
                 }
                 Some("#") => {
@@ -215,6 +223,45 @@ impl<'a> Lexer<'a> {
         Ok(Token::from_bang(*first_location))
     }
 
+    /// Returns a conjunction token `그리고` if successfully lexed, or error otherwise.
+    ///
+    /// Call after advancing the scanner `self.scanner` past the initial character `그`, with its location passed as `first_location`.
+    // TODO: document other functions like this.
+    fn lex_conjunct(&mut self, first_location: &Range) -> ResToken {
+        // TODO: more readable than using match as in `lex_false()` and `lex_num()`? then refactor them
+        let second_char = self.scanner.read();
+        let Some("리") = second_char else {
+            // TODO: return an identifier token, when the identifier token is implemented.
+            return Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()));
+        };
+
+        self.scanner.advance();
+        let third_char = self.scanner.read();
+        let Some("고") = third_char else {
+            // TODO: return an identifier token, when the identifier token is implemented.
+            return Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()));
+        };
+
+        let location = Range::new(first_location.begin, self.scanner.locate().end);
+        self.scanner.advance();
+        // TODO: enough to make a token, is helper function `from_*()` in syntax token library really necessary, or just increasing bundled output size?
+        Ok(Token::new(TokenKind::Conjunct, location))
+    }
+
+    /// Returns a conjunction token `또는` if successfully lexed, or error otherwise.
+    ///
+    /// Call after advancing the scanner `self.scanner` past the initial character `또`, with its location passed as `first_location`.
+    fn lex_disjunct(&mut self, first_location: &Range) -> ResToken {
+        let second_char = self.scanner.read();
+        let Some("는") = second_char else {
+            return Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()));
+        };
+
+        let location = Range::new(first_location.begin, self.scanner.locate().end);
+        self.scanner.advance();
+        Ok(Token::new(TokenKind::Disjunct, location))
+    }
+
     fn skip_comment(&mut self) -> () {
         loop {
             match self.scanner.read() {
@@ -313,6 +360,8 @@ mod tests {
     #[case::lparen("(", vec![mktoken!(TokenKind::LParen, loc 0, 0, 0, 1)])]
     #[case::rparen(")", vec![mktoken!(TokenKind::RParen, loc 0, 0, 0, 1)])]
     #[case::bang("!", vec![mktoken!(TokenKind::Bang, loc 0, 0, 0, 1)])]
+    #[case::bang("그리고", vec![mktoken!(TokenKind::Conjunct, loc 0, 0, 0, 3)])]
+    #[case::bang("또는", vec![mktoken!(TokenKind::Disjunct, loc 0, 0, 0, 2)])]
     fn single_token(#[case] source: &str, #[case] expected: Vec<Token>) {
         assert_lex!(source, expected);
     }

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -15,6 +15,8 @@ pub enum AstKind {
     InfixAsterisk { left: Box<Ast>, right: Box<Ast> },
     InfixSlash { left: Box<Ast>, right: Box<Ast> },
     InfixPercent { left: Box<Ast>, right: Box<Ast> },
+    InfixConjunct { left: Box<Ast>, right: Box<Ast> },
+    InfixDisjunct { left: Box<Ast>, right: Box<Ast> },
 }
 
 /// An abstract syntax tree, or AST produced during parsing.
@@ -29,6 +31,7 @@ impl Ast {
         Ast { kind, location }
     }
 
+    // TODO: really need to use `from_*()` functions, instead of `new()`??
     pub fn from_program(expressions: Vec<Box<Ast>>) -> Self {
         let location = Self::locate_expressions(&expressions);
 

--- a/komi_syntax/src/bp/mod.rs
+++ b/komi_syntax/src/bp/mod.rs
@@ -7,6 +7,8 @@ pub struct Bp {
 }
 
 static LOWEST_BP: Bp = Bp { left: 0o0, right: 0o1 };
+// TODO: use the static bp instead of `get_*()` functions, to reduce bundled size
+pub const CONNECTIVE_BP: Bp = Bp { left: 0o20, right: 0o21 };
 static ADDITIVE_BP: Bp = Bp { left: 0o30, right: 0o31 };
 static MULTIPLICATIVE_BP: Bp = Bp { left: 0o40, right: 0o41 };
 static PREFIX_BP: Bp = Bp { left: 0o70, right: 0o71 };
@@ -32,6 +34,7 @@ impl Bp {
         match token.kind {
             TokenKind::Plus | TokenKind::Minus => &ADDITIVE_BP,
             TokenKind::Asterisk | TokenKind::Slash | TokenKind::Percent => &MULTIPLICATIVE_BP,
+            TokenKind::Conjunct | TokenKind::Disjunct => &CONNECTIVE_BP,
             _ => &LOWEST_BP,
         }
     }

--- a/komi_syntax/src/token/mod.rs
+++ b/komi_syntax/src/token/mod.rs
@@ -24,6 +24,10 @@ pub enum TokenKind {
     RParen,
     /// A bang `!`.
     Bang,
+    /// A conjunction `그리고`.
+    Conjunct,
+    /// A disjunction `또는`.
+    Disjunct,
 }
 
 /// A token produced during lexing.
@@ -38,6 +42,7 @@ impl Token {
         Token { kind, location }
     }
 
+    // TODO: really need to use `from_*()` functions, instead of `new()`??
     pub const fn from_num(num: f64, location: Range) -> Self {
         Token::new(TokenKind::Number(num), location)
     }

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -199,28 +199,24 @@ mod tests {
                     use super::*;
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_true_and_true() -> Result<(), JsValue> {
                         assert_exec!("참 그리고 참", "참");
                         Ok(())
                     }
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_true_and_false() -> Result<(), JsValue> {
                         assert_exec!("참 그리고 거짓", "거짓");
                         Ok(())
                     }
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_false_and_true() -> Result<(), JsValue> {
                         assert_exec!("거짓 그리고 참", "거짓");
                         Ok(())
                     }
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_false_and_false() -> Result<(), JsValue> {
                         assert_exec!("거짓 그리고 거짓", "거짓");
                         Ok(())
@@ -231,30 +227,36 @@ mod tests {
                     use super::*;
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_true_or_true() -> Result<(), JsValue> {
                         assert_exec!("참 또는 참", "참");
                         Ok(())
                     }
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_true_or_false() -> Result<(), JsValue> {
                         assert_exec!("참 또는 거짓", "참");
                         Ok(())
                     }
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_false_or_true() -> Result<(), JsValue> {
                         assert_exec!("거짓 또는 참", "참");
                         Ok(())
                     }
 
                     #[wasm_bindgen_test]
-                    #[ignore]
                     fn test_false_or_false() -> Result<(), JsValue> {
                         assert_exec!("거짓 또는 거짓", "거짓");
+                        Ok(())
+                    }
+                }
+
+                mod compound {
+                    use super::*;
+
+                    #[wasm_bindgen_test]
+                    fn test_negation_on_conjunction() -> Result<(), JsValue> {
+                        assert_exec!("!(참 또는 참)", "거짓");
                         Ok(())
                     }
                 }


### PR DESCRIPTION
added keyword conjunction `그리고`, disjunction `또는`.