### PR TITLE
modularize abstract syntax tree walking logic

### DIFF
--- a/komi_evaluator/src/ast_reducer/expressions/mod.rs
+++ b/komi_evaluator/src/ast_reducer/expressions/mod.rs
@@ -1,0 +1,19 @@
+use super::reduce_ast;
+use crate::err::EvalError;
+use komi_syntax::{Ast, Value};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+/// Returns the evaluated result of the last AST in the ASTs `expressions`.
+///
+/// Sets its location to be `expressions_location`, since it represents the entire expressions, not a single one.
+pub fn reduce(expressions: &Vec<Box<Ast>>, expressions_location: &Range) -> ResVal {
+    let mut last_value = Value::from_empty(*expressions_location);
+
+    for expression in expressions {
+        last_value = reduce_ast(expression)?;
+    }
+    last_value.location = *expressions_location;
+    Ok(last_value)
+}

--- a/komi_evaluator/src/ast_reducer/infix/infix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/infix/infix_reducer/mod.rs
@@ -1,0 +1,63 @@
+use super::util;
+use crate::err::{EvalError, EvalErrorKind};
+use komi_syntax::{Ast, Value, ValueKind};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+/// Reduces the operand `operand` of a numeric infix operand to a value.
+/// Its primitive value and kind are determined by `reduce_infix` and `get_kind`, respectively.
+pub fn reduce_num<F, G>(left: &Ast, right: &Ast, location: &Range, reduce_infix: F, get_kind: G) -> ResVal
+where
+    F: Fn(f64, f64) -> f64,
+    G: Fn(f64) -> ValueKind,
+{
+    reduce(left, right, location, get_num_primitive, reduce_infix, get_kind)
+}
+
+/// Reduces the operand `operand` of a boolean infix operand to a value.
+/// Its primitive value and kind are determined by `reduce_infix` and `get_kind`, respectively.
+pub fn reduce_bool<F, G>(left: &Ast, right: &Ast, location: &Range, reduce_infix: F, get_kind: G) -> ResVal
+where
+    F: Fn(bool, bool) -> bool,
+    G: Fn(bool) -> ValueKind,
+{
+    reduce(left, right, location, get_bool_primitive, reduce_infix, get_kind)
+}
+
+fn get_num_primitive(ast: &Ast) -> Result<f64, EvalError> {
+    util::get_num_primitive_or_error(ast, EvalErrorKind::InvalidAdditionOperand)
+}
+
+fn get_bool_primitive(ast: &Ast) -> Result<bool, EvalError> {
+    util::get_bool_primitive_or_error(ast, EvalErrorKind::InvalidConnectiveInfixOperand)
+}
+
+/// Reduces the operand `operand` of an infix to a value.
+///
+/// - `reduce_operand` determines how to reduce the `left` and `right` themselves to some values `x` and `y`, respectively.
+/// - `reduce_infix` maps `x` and `y` to `z`, at the primitive level.
+/// - `get_kind` specifies what kind to return from `z`.
+///
+/// The location is determined by `location`.
+fn reduce<T, F, G, H>(
+    left: &Ast,
+    right: &Ast,
+    location: &Range,
+    reduce_operand: F,
+    reduce_infix: G,
+    get_kind: H,
+) -> ResVal
+where
+    F: Fn(&Ast) -> Result<T, EvalError>,
+    G: Fn(T, T) -> T,
+    H: Fn(T) -> ValueKind,
+{
+    let left_val = reduce_operand(left)?;
+    let right_val = reduce_operand(right)?;
+    let infix_val = reduce_infix(left_val, right_val);
+
+    let kind = get_kind(infix_val);
+
+    Ok(Value::new(kind, *location))
+}

--- a/komi_evaluator/src/ast_reducer/infix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/infix/mod.rs
@@ -1,0 +1,43 @@
+mod infix_reducer;
+
+use super::util;
+use crate::err::EvalError;
+use komi_syntax::{Ast, Value, ValueKind};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+/// Reduces the operands `left` and `right` of a plus infix to a value.
+pub fn reduce_plus(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_num(left, right, infix_location, |l, r| l + r, |v| ValueKind::Number(v))
+}
+
+/// Reduces the operands `left` and `right` of a minus infix to a value.
+pub fn reduce_minus(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_num(left, right, infix_location, |l, r| l - r, |v| ValueKind::Number(v))
+}
+
+/// Reduces the operands `left` and `right` of a asterisk infix to a value.
+pub fn reduce_asterisk(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_num(left, right, infix_location, |l, r| l * r, |v| ValueKind::Number(v))
+}
+
+/// Reduces the operands `left` and `right` of a slash infix to a value.
+pub fn reduce_slash(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_num(left, right, infix_location, |l, r| l / r, |v| ValueKind::Number(v))
+}
+
+/// Reduces the operands `left` and `right` of a percent infix to a value.
+pub fn reduce_percent(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_num(left, right, infix_location, |l, r| l % r, |v| ValueKind::Number(v))
+}
+
+/// Reduces the operands `left` and `right` of a conjunction infix to a value.
+pub fn reduce_conjunct(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_bool(left, right, infix_location, |l, r| l && r, |v| ValueKind::Bool(v))
+}
+
+/// Reduces the operands `left` and `right` of a disjunction infix to a value.
+pub fn reduce_disjunct(left: &Ast, right: &Ast, infix_location: &Range) -> ResVal {
+    infix_reducer::reduce_bool(left, right, infix_location, |l, r| l || r, |v| ValueKind::Bool(v))
+}

--- a/komi_evaluator/src/ast_reducer/leaf/mod.rs
+++ b/komi_evaluator/src/ast_reducer/leaf/mod.rs
@@ -1,0 +1,15 @@
+use crate::err::EvalError;
+use komi_syntax::{Value, ValueKind};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+/// Returns the evaluated numeric result, from number `num` and its location `location`.
+pub fn evaluate_num(num: f64, location: &Range) -> ResVal {
+    Ok(Value::new(ValueKind::Number(num), *location))
+}
+
+/// Returns the evaluated boolean result, from boolean `boolean` and its location `location`.
+pub fn evaluate_bool(boolean: bool, location: &Range) -> ResVal {
+    Ok(Value::new(ValueKind::Bool(boolean), *location))
+}

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -1,0 +1,223 @@
+use crate::err::{EvalError, EvalErrorKind};
+use komi_syntax::{Ast, AstKind, Value, ValueKind};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+pub fn reduce_ast(ast: &Ast) -> ResVal {
+    let loc = ast.location;
+    match &ast.kind {
+        AstKind::Program { expressions: e } => evaluate_expressions(&e, &loc),
+        AstKind::Number(x) => evaluate_number(*x, &loc),
+        AstKind::Bool(x) => evaluate_bool(*x, &loc),
+        AstKind::PrefixPlus { operand: op } => evaluate_prefix_plus(&op, &loc),
+        AstKind::PrefixMinus { operand: op } => evaluate_prefix_minus(&op, &loc),
+        AstKind::PrefixBang { operand: op } => evaluate_prefix_bang(&op, &loc),
+        AstKind::InfixPlus { left, right } => eval_infix_plus(&left, &right),
+        AstKind::InfixMinus { left, right } => eval_infix_minus(&left, &right),
+        AstKind::InfixAsterisk { left, right } => eval_infix_asterisk(&left, &right),
+        AstKind::InfixSlash { left, right } => eval_infix_slash(&left, &right),
+        AstKind::InfixPercent { left, right } => eval_infix_percent(&left, &right),
+        AstKind::InfixConjunct { left, right } => eval_infix_conjunct(&left, &right),
+        AstKind::InfixDisjunct { left, right } => eval_infix_disjunct(&left, &right),
+    }
+}
+
+/// Returns the evaluated result of the last AST in the ASTs `expressions`.
+///
+/// Sets its location to be `expressions_location`, since it represents the entire expressions, not a single one.
+fn evaluate_expressions(expressions: &Vec<Box<Ast>>, expressions_location: &Range) -> ResVal {
+    let mut last_value = Value::from_empty(*expressions_location);
+
+    for expression in expressions {
+        last_value = reduce_ast(expression)?;
+    }
+    last_value.location = *expressions_location;
+    Ok(last_value)
+}
+
+/// Returns the evaluated numeric result, from number `num` and its location `location`.
+fn evaluate_number(num: f64, location: &Range) -> ResVal {
+    Ok(Value::new(ValueKind::Number(num), *location))
+}
+
+/// Returns the evaluated boolean result, from boolean `boolean` and its location `location`.
+fn evaluate_bool(boolean: bool, location: &Range) -> ResVal {
+    Ok(Value::new(ValueKind::Bool(boolean), *location))
+}
+
+/// Returns the evaluated numeric result of the AST `operand` as an operand of the prefix plus.
+///
+/// The location in the returned value will span from the prefix to operand.
+fn evaluate_prefix_plus(operand: &Ast, prefix_location: &Range) -> ResVal {
+    evaluate_num_prefix(operand, prefix_location, |v| ValueKind::Number(v))
+}
+
+/// Returns the evaluated numeric result of the AST `operand` as an operand of the prefix minus.
+///
+/// The location in the returned value will span from the prefix to operand.
+fn evaluate_prefix_minus(operand: &Ast, prefix_location: &Range) -> ResVal {
+    evaluate_num_prefix(operand, prefix_location, |v| ValueKind::Number(-v))
+}
+
+/// Returns the evaluated boolean result of the AST `operand` as an operand of the prefix bang.
+///
+/// The location in the returned value will span from the prefix to operand.
+fn evaluate_prefix_bang(operand: &Ast, prefix_location: &Range) -> ResVal {
+    evaluate_bool_prefix(operand, prefix_location, |v| ValueKind::Bool(!v))
+}
+
+fn eval_infix_plus(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_num_infix(left, right, |l, r| l + r, |v| ValueKind::Number(v))
+}
+
+fn eval_infix_minus(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_num_infix(left, right, |l, r| l - r, |v| ValueKind::Number(v))
+}
+
+fn eval_infix_asterisk(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_num_infix(left, right, |l, r| l * r, |v| ValueKind::Number(v))
+}
+
+fn eval_infix_slash(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_num_infix(left, right, |l, r| l / r, |v| ValueKind::Number(v))
+}
+
+fn eval_infix_percent(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_num_infix(left, right, |l, r| l % r, |v| ValueKind::Number(v))
+}
+
+fn eval_infix_conjunct(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_bool_infix(left, right, |l, r| l && r, |v| ValueKind::Bool(v))
+}
+
+fn eval_infix_disjunct(left: &Ast, right: &Ast) -> ResVal {
+    evaluate_bool_infix(left, right, |l, r| l || r, |v| ValueKind::Bool(v))
+}
+
+/// Returns the evaluated numeric result of the AST `operand` as a leaf operand of a prefix.
+fn evaluate_num_prefix_operand(operand: &Ast) -> Result<f64, EvalError> {
+    evaluate_leaf_operand(operand, |value_kind| match value_kind {
+        ValueKind::Number(x) => Ok(*x),
+        _ => Err(EvalErrorKind::InvalidPrefixNumOperand),
+    })
+}
+
+/// Returns the evaluated boolean result of the AST `operand` as a leaf operand of a prefix.
+fn evaluate_bool_prefix_operand(operand: &Ast) -> Result<bool, EvalError> {
+    evaluate_leaf_operand(operand, |value_kind| match value_kind {
+        ValueKind::Bool(x) => Ok(*x),
+        _ => Err(EvalErrorKind::InvalidPrefixBoolOperand),
+    })
+}
+
+/// Returns the evaluated numeric result of the AST `operand` as a leaf operand of an infix.
+fn evaluate_num_infix_operand(operand: &Ast) -> Result<f64, EvalError> {
+    evaluate_leaf_operand(operand, |value_kind| match value_kind {
+        ValueKind::Number(x) => Ok(*x),
+        _ => Err(EvalErrorKind::InvalidAdditionOperand),
+    })
+}
+
+/// Returns the evaluated boolean result of the AST `operand` as a leaf operand of an infix.
+fn evaluate_bool_infix_operand(operand: &Ast) -> Result<bool, EvalError> {
+    evaluate_leaf_operand(operand, |value_kind| match value_kind {
+        ValueKind::Bool(x) => Ok(*x),
+        _ => Err(EvalErrorKind::InvalidConnectiveInfixOperand),
+    })
+}
+
+fn evaluate_num_prefix<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
+where
+    F: Fn(f64) -> ValueKind,
+{
+    evaluate_prefix(operand, prefix_location, evaluate_num_prefix_operand, get_kind)
+}
+
+fn evaluate_bool_prefix<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
+where
+    F: Fn(bool) -> ValueKind,
+{
+    evaluate_prefix::<bool, _, _>(operand, prefix_location, evaluate_bool_prefix_operand, get_kind)
+}
+
+/// Returns the evaluated result of the AST `operand` as an operand of a prefix.
+///
+/// - `evaluate_operand` determines how to evaluate the AST `operand` itself to some value `x`.
+/// - `get_kind` specifies how to get the value kind from `x`.
+///
+/// The location in the returned value will span from the prefix to operand.
+fn evaluate_prefix<T, F, G>(operand: &Ast, prefix_location: &Range, evaluate_operand: F, get_kind: G) -> ResVal
+where
+    F: Fn(&Ast) -> Result<T, EvalError>,
+    G: Fn(T) -> ValueKind,
+{
+    let evaluated_operand = evaluate_operand(operand)?;
+    let kind = get_kind(evaluated_operand);
+    let location = Range::new(prefix_location.begin, operand.location.end);
+    Ok(Value::new(kind, location))
+}
+
+fn evaluate_bool_infix<F, G>(left: &Ast, right: &Ast, evaluate_infix: F, make_value_kind: G) -> ResVal
+where
+    F: Fn(bool, bool) -> bool,
+    G: Fn(bool) -> ValueKind,
+{
+    evaluate_infix_(
+        left,
+        right,
+        evaluate_bool_infix_operand,
+        evaluate_infix,
+        make_value_kind,
+    )
+}
+
+fn evaluate_num_infix<F, G>(left: &Ast, right: &Ast, evaluate_infix: F, make_value_kind: G) -> ResVal
+where
+    F: Fn(f64, f64) -> f64,
+    G: Fn(f64) -> ValueKind,
+{
+    evaluate_infix_(left, right, evaluate_num_infix_operand, evaluate_infix, make_value_kind)
+}
+
+// TODO: document
+// TODO(?): factor out into separate file
+pub fn evaluate_infix_<T, F, G, H>(
+    left: &Ast,
+    right: &Ast,
+    evaluate_operand: F,
+    evaluate_infix: G,
+    make_value_kind: H,
+) -> ResVal
+where
+    F: Fn(&Ast) -> Result<T, EvalError>,
+    G: Fn(T, T) -> T,
+    H: Fn(T) -> ValueKind,
+{
+    let left_val = evaluate_operand(left)?;
+    let right_val = evaluate_operand(right)?;
+
+    let infix_val = evaluate_infix(left_val, right_val);
+
+    let kind = make_value_kind(infix_val);
+    let location = Range::new(left.location.begin, right.location.end);
+
+    Ok(Value::new(kind, location))
+}
+
+/// Returns the evalauted result of the AST `operand` as a leaf operand of a prefix or an infix.
+///
+/// `extract` specifies the expected kind `x` of the evaluated result of `operand`.
+/// - If `x` encountered, it returns `Ok` from `x`.
+/// - Otherwise, returns `Err(e)` where `e` is `EvalError`.
+fn evaluate_leaf_operand<T, F>(operand: &Ast, extract: F) -> Result<T, EvalError>
+where
+    F: Fn(&ValueKind) -> Result<T, EvalErrorKind>,
+{
+    let val = reduce_ast(operand)?;
+
+    match extract(&val.kind) {
+        Ok(x) => Ok(x),
+        Err(kind) => Err(EvalError::new(kind, val.location)),
+    }
+}

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -1,223 +1,34 @@
-use crate::err::{EvalError, EvalErrorKind};
-use komi_syntax::{Ast, AstKind, Value, ValueKind};
-use komi_util::Range;
+mod expressions;
+mod infix;
+mod leaf;
+mod prefix;
+mod util;
+
+use crate::err::EvalError;
+use komi_syntax::{Ast, AstKind, Value};
 
 type ResVal = Result<Value, EvalError>;
 
 pub fn reduce_ast(ast: &Ast) -> ResVal {
+    // Design principle: once you read something, pass it as an argument.
+    // This avoids unnecessary repeated reading in subfunctions.
+    // Moreover, if you delay determining the kind of what you read, the decision is only postponed to subfunctions.
+    // You'll have to handle exceptional cases that could have been avoided.
+
     let loc = ast.location;
     match &ast.kind {
-        AstKind::Program { expressions: e } => evaluate_expressions(&e, &loc),
-        AstKind::Number(x) => evaluate_number(*x, &loc),
-        AstKind::Bool(x) => evaluate_bool(*x, &loc),
-        AstKind::PrefixPlus { operand: op } => evaluate_prefix_plus(&op, &loc),
-        AstKind::PrefixMinus { operand: op } => evaluate_prefix_minus(&op, &loc),
-        AstKind::PrefixBang { operand: op } => evaluate_prefix_bang(&op, &loc),
-        AstKind::InfixPlus { left, right } => eval_infix_plus(&left, &right),
-        AstKind::InfixMinus { left, right } => eval_infix_minus(&left, &right),
-        AstKind::InfixAsterisk { left, right } => eval_infix_asterisk(&left, &right),
-        AstKind::InfixSlash { left, right } => eval_infix_slash(&left, &right),
-        AstKind::InfixPercent { left, right } => eval_infix_percent(&left, &right),
-        AstKind::InfixConjunct { left, right } => eval_infix_conjunct(&left, &right),
-        AstKind::InfixDisjunct { left, right } => eval_infix_disjunct(&left, &right),
-    }
-}
-
-/// Returns the evaluated result of the last AST in the ASTs `expressions`.
-///
-/// Sets its location to be `expressions_location`, since it represents the entire expressions, not a single one.
-fn evaluate_expressions(expressions: &Vec<Box<Ast>>, expressions_location: &Range) -> ResVal {
-    let mut last_value = Value::from_empty(*expressions_location);
-
-    for expression in expressions {
-        last_value = reduce_ast(expression)?;
-    }
-    last_value.location = *expressions_location;
-    Ok(last_value)
-}
-
-/// Returns the evaluated numeric result, from number `num` and its location `location`.
-fn evaluate_number(num: f64, location: &Range) -> ResVal {
-    Ok(Value::new(ValueKind::Number(num), *location))
-}
-
-/// Returns the evaluated boolean result, from boolean `boolean` and its location `location`.
-fn evaluate_bool(boolean: bool, location: &Range) -> ResVal {
-    Ok(Value::new(ValueKind::Bool(boolean), *location))
-}
-
-/// Returns the evaluated numeric result of the AST `operand` as an operand of the prefix plus.
-///
-/// The location in the returned value will span from the prefix to operand.
-fn evaluate_prefix_plus(operand: &Ast, prefix_location: &Range) -> ResVal {
-    evaluate_num_prefix(operand, prefix_location, |v| ValueKind::Number(v))
-}
-
-/// Returns the evaluated numeric result of the AST `operand` as an operand of the prefix minus.
-///
-/// The location in the returned value will span from the prefix to operand.
-fn evaluate_prefix_minus(operand: &Ast, prefix_location: &Range) -> ResVal {
-    evaluate_num_prefix(operand, prefix_location, |v| ValueKind::Number(-v))
-}
-
-/// Returns the evaluated boolean result of the AST `operand` as an operand of the prefix bang.
-///
-/// The location in the returned value will span from the prefix to operand.
-fn evaluate_prefix_bang(operand: &Ast, prefix_location: &Range) -> ResVal {
-    evaluate_bool_prefix(operand, prefix_location, |v| ValueKind::Bool(!v))
-}
-
-fn eval_infix_plus(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_num_infix(left, right, |l, r| l + r, |v| ValueKind::Number(v))
-}
-
-fn eval_infix_minus(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_num_infix(left, right, |l, r| l - r, |v| ValueKind::Number(v))
-}
-
-fn eval_infix_asterisk(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_num_infix(left, right, |l, r| l * r, |v| ValueKind::Number(v))
-}
-
-fn eval_infix_slash(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_num_infix(left, right, |l, r| l / r, |v| ValueKind::Number(v))
-}
-
-fn eval_infix_percent(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_num_infix(left, right, |l, r| l % r, |v| ValueKind::Number(v))
-}
-
-fn eval_infix_conjunct(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_bool_infix(left, right, |l, r| l && r, |v| ValueKind::Bool(v))
-}
-
-fn eval_infix_disjunct(left: &Ast, right: &Ast) -> ResVal {
-    evaluate_bool_infix(left, right, |l, r| l || r, |v| ValueKind::Bool(v))
-}
-
-/// Returns the evaluated numeric result of the AST `operand` as a leaf operand of a prefix.
-fn evaluate_num_prefix_operand(operand: &Ast) -> Result<f64, EvalError> {
-    evaluate_leaf_operand(operand, |value_kind| match value_kind {
-        ValueKind::Number(x) => Ok(*x),
-        _ => Err(EvalErrorKind::InvalidPrefixNumOperand),
-    })
-}
-
-/// Returns the evaluated boolean result of the AST `operand` as a leaf operand of a prefix.
-fn evaluate_bool_prefix_operand(operand: &Ast) -> Result<bool, EvalError> {
-    evaluate_leaf_operand(operand, |value_kind| match value_kind {
-        ValueKind::Bool(x) => Ok(*x),
-        _ => Err(EvalErrorKind::InvalidPrefixBoolOperand),
-    })
-}
-
-/// Returns the evaluated numeric result of the AST `operand` as a leaf operand of an infix.
-fn evaluate_num_infix_operand(operand: &Ast) -> Result<f64, EvalError> {
-    evaluate_leaf_operand(operand, |value_kind| match value_kind {
-        ValueKind::Number(x) => Ok(*x),
-        _ => Err(EvalErrorKind::InvalidAdditionOperand),
-    })
-}
-
-/// Returns the evaluated boolean result of the AST `operand` as a leaf operand of an infix.
-fn evaluate_bool_infix_operand(operand: &Ast) -> Result<bool, EvalError> {
-    evaluate_leaf_operand(operand, |value_kind| match value_kind {
-        ValueKind::Bool(x) => Ok(*x),
-        _ => Err(EvalErrorKind::InvalidConnectiveInfixOperand),
-    })
-}
-
-fn evaluate_num_prefix<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
-where
-    F: Fn(f64) -> ValueKind,
-{
-    evaluate_prefix(operand, prefix_location, evaluate_num_prefix_operand, get_kind)
-}
-
-fn evaluate_bool_prefix<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
-where
-    F: Fn(bool) -> ValueKind,
-{
-    evaluate_prefix::<bool, _, _>(operand, prefix_location, evaluate_bool_prefix_operand, get_kind)
-}
-
-/// Returns the evaluated result of the AST `operand` as an operand of a prefix.
-///
-/// - `evaluate_operand` determines how to evaluate the AST `operand` itself to some value `x`.
-/// - `get_kind` specifies how to get the value kind from `x`.
-///
-/// The location in the returned value will span from the prefix to operand.
-fn evaluate_prefix<T, F, G>(operand: &Ast, prefix_location: &Range, evaluate_operand: F, get_kind: G) -> ResVal
-where
-    F: Fn(&Ast) -> Result<T, EvalError>,
-    G: Fn(T) -> ValueKind,
-{
-    let evaluated_operand = evaluate_operand(operand)?;
-    let kind = get_kind(evaluated_operand);
-    let location = Range::new(prefix_location.begin, operand.location.end);
-    Ok(Value::new(kind, location))
-}
-
-fn evaluate_bool_infix<F, G>(left: &Ast, right: &Ast, evaluate_infix: F, make_value_kind: G) -> ResVal
-where
-    F: Fn(bool, bool) -> bool,
-    G: Fn(bool) -> ValueKind,
-{
-    evaluate_infix_(
-        left,
-        right,
-        evaluate_bool_infix_operand,
-        evaluate_infix,
-        make_value_kind,
-    )
-}
-
-fn evaluate_num_infix<F, G>(left: &Ast, right: &Ast, evaluate_infix: F, make_value_kind: G) -> ResVal
-where
-    F: Fn(f64, f64) -> f64,
-    G: Fn(f64) -> ValueKind,
-{
-    evaluate_infix_(left, right, evaluate_num_infix_operand, evaluate_infix, make_value_kind)
-}
-
-// TODO: document
-// TODO(?): factor out into separate file
-pub fn evaluate_infix_<T, F, G, H>(
-    left: &Ast,
-    right: &Ast,
-    evaluate_operand: F,
-    evaluate_infix: G,
-    make_value_kind: H,
-) -> ResVal
-where
-    F: Fn(&Ast) -> Result<T, EvalError>,
-    G: Fn(T, T) -> T,
-    H: Fn(T) -> ValueKind,
-{
-    let left_val = evaluate_operand(left)?;
-    let right_val = evaluate_operand(right)?;
-
-    let infix_val = evaluate_infix(left_val, right_val);
-
-    let kind = make_value_kind(infix_val);
-    let location = Range::new(left.location.begin, right.location.end);
-
-    Ok(Value::new(kind, location))
-}
-
-/// Returns the evalauted result of the AST `operand` as a leaf operand of a prefix or an infix.
-///
-/// `extract` specifies the expected kind `x` of the evaluated result of `operand`.
-/// - If `x` encountered, it returns `Ok` from `x`.
-/// - Otherwise, returns `Err(e)` where `e` is `EvalError`.
-fn evaluate_leaf_operand<T, F>(operand: &Ast, extract: F) -> Result<T, EvalError>
-where
-    F: Fn(&ValueKind) -> Result<T, EvalErrorKind>,
-{
-    let val = reduce_ast(operand)?;
-
-    match extract(&val.kind) {
-        Ok(x) => Ok(x),
-        Err(kind) => Err(EvalError::new(kind, val.location)),
+        AstKind::Program { expressions: e } => expressions::reduce(&e, &loc),
+        AstKind::Number(x) => leaf::evaluate_num(*x, &loc),
+        AstKind::Bool(x) => leaf::evaluate_bool(*x, &loc),
+        AstKind::PrefixPlus { operand: op } => prefix::reduce_plus(&op, &loc),
+        AstKind::PrefixMinus { operand: op } => prefix::reduce_minus(&op, &loc),
+        AstKind::PrefixBang { operand: op } => prefix::reduce_bang(&op, &loc),
+        AstKind::InfixPlus { left: l, right: r } => infix::reduce_plus(&l, &r, &loc),
+        AstKind::InfixMinus { left: l, right: r } => infix::reduce_minus(&l, &r, &loc),
+        AstKind::InfixAsterisk { left: l, right: r } => infix::reduce_asterisk(&l, &r, &loc),
+        AstKind::InfixSlash { left: l, right: r } => infix::reduce_slash(&l, &r, &loc),
+        AstKind::InfixPercent { left: l, right: r } => infix::reduce_percent(&l, &r, &loc),
+        AstKind::InfixConjunct { left: l, right: r } => infix::reduce_conjunct(&l, &r, &loc),
+        AstKind::InfixDisjunct { left: l, right: r } => infix::reduce_disjunct(&l, &r, &loc),
     }
 }

--- a/komi_evaluator/src/ast_reducer/prefix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/prefix/mod.rs
@@ -1,0 +1,22 @@
+mod prefix_reducer;
+
+use crate::err::EvalError;
+use komi_syntax::{Ast, Value, ValueKind};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+/// Reduces the operand `operand` of a plus prefix to a value, with its location spanning from the prefix to the operand.
+pub fn reduce_plus(operand: &Ast, prefix_location: &Range) -> ResVal {
+    prefix_reducer::reduce_num(operand, prefix_location, |v| ValueKind::Number(v))
+}
+
+/// Reduces the operand `operand` of a plus prefix to a value, with its location spanning from the prefix to the operand.
+pub fn reduce_minus(operand: &Ast, prefix_location: &Range) -> ResVal {
+    prefix_reducer::reduce_num(operand, prefix_location, |v| ValueKind::Number(-v))
+}
+
+/// Reduces the operand `operand` of a plus prefix to a value, with its location spanning from the prefix to the operand.
+pub fn reduce_bang(operand: &Ast, prefix_location: &Range) -> ResVal {
+    prefix_reducer::reduce_bool(operand, prefix_location, |v| ValueKind::Bool(!v))
+}

--- a/komi_evaluator/src/ast_reducer/prefix/prefix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/prefix/prefix_reducer/mod.rs
@@ -1,0 +1,49 @@
+use crate::ast_reducer::util;
+use crate::err::{EvalError, EvalErrorKind};
+use komi_syntax::{Ast, Value, ValueKind};
+use komi_util::Range;
+
+type ResVal = Result<Value, EvalError>;
+
+/// Reduces the operand `operand` of a numeric prefix operand to a value, with its kind determined by `get_kind`.
+pub fn reduce_num<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
+where
+    F: Fn(f64) -> ValueKind,
+{
+    reduce(operand, prefix_location, get_num_primitive, get_kind)
+}
+
+/// Reduces the operand `operand` of a boolean prefix operand to a value, with its kind determined by `get_kind`.
+pub fn reduce_bool<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
+where
+    F: Fn(bool) -> ValueKind,
+{
+    reduce(operand, prefix_location, get_bool_primitive, get_kind)
+}
+
+fn get_num_primitive(ast: &Ast) -> Result<f64, EvalError> {
+    util::get_num_primitive_or_error(ast, EvalErrorKind::InvalidPrefixNumOperand)
+}
+
+fn get_bool_primitive(ast: &Ast) -> Result<bool, EvalError> {
+    util::get_bool_primitive_or_error(ast, EvalErrorKind::InvalidPrefixBoolOperand)
+}
+
+/// Reduces the operand `operand` of a prefix to an evaluated result.
+///
+/// - `reduce_operand` determines how to reduce the `operand` itself to some value `x`.
+/// - `get_kind` specifies what kind to return from `x`.
+///
+/// The location in the returned value will span from the prefix to operand.
+fn reduce<T, F, G>(operand: &Ast, prefix_location: &Range, reduce_operand: F, get_kind: G) -> ResVal
+where
+    F: Fn(&Ast) -> Result<T, EvalError>,
+    G: Fn(T) -> ValueKind,
+{
+    let reduced = reduce_operand(operand)?;
+    let kind = get_kind(reduced);
+
+    let location = Range::new(prefix_location.begin, operand.location.end);
+
+    Ok(Value::new(kind, location))
+}

--- a/komi_evaluator/src/ast_reducer/util/mod.rs
+++ b/komi_evaluator/src/ast_reducer/util/mod.rs
@@ -1,0 +1,32 @@
+use super::reduce_ast;
+use crate::err::{EvalError, EvalErrorKind};
+use komi_syntax::{Ast, ValueKind};
+
+/// Reduces the AST `ast` to an evaluated result, and map it with `op`.
+///
+/// `op` should return `EvalErrorKind` on erroneous case, which then automatically converted into `EvalError` in the returned result.
+pub fn reduce_and_map_kind<T, F>(ast: &Ast, op: F) -> Result<T, EvalError>
+where
+    F: Fn(&ValueKind) -> Result<T, EvalErrorKind>,
+{
+    let val = reduce_ast(ast)?;
+
+    match op(&val.kind) {
+        Ok(x) => Ok(x),
+        Err(kind) => Err(EvalError::new(kind, val.location)),
+    }
+}
+
+pub fn get_num_primitive_or_error(ast: &Ast, error_kind: EvalErrorKind) -> Result<f64, EvalError> {
+    reduce_and_map_kind(ast, |kind| match kind {
+        ValueKind::Number(x) => Ok(*x),
+        _ => Err(error_kind.clone()),
+    })
+}
+
+pub fn get_bool_primitive_or_error(ast: &Ast, error_kind: EvalErrorKind) -> Result<bool, EvalError> {
+    reduce_and_map_kind(ast, |kind| match kind {
+        ValueKind::Bool(x) => Ok(*x),
+        _ => Err(error_kind.clone()),
+    })
+}

--- a/komi_evaluator/src/err/mod.rs
+++ b/komi_evaluator/src/err/mod.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// Errors that may occur during the evaluating process.
 /// Serves as the interface between a evaluator and its user.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum EvalErrorKind {
     InvalidAdditionOperand, // TODO: rename, because it is not only for addition, but for arithmetic infix.
     InvalidConnectiveInfixOperand,

--- a/komi_evaluator/src/lib.rs
+++ b/komi_evaluator/src/lib.rs
@@ -4,11 +4,12 @@
 //! Note that *value* is a technical term referring to the result of evaluation.
 //! Designed to be loosely coupled, so it does not rely on the implementation details of the parser.
 
+mod ast_reducer;
 mod err;
 
+use ast_reducer::reduce_ast;
 pub use err::{EvalError, EvalErrorKind};
-use komi_syntax::{Ast, AstKind, Value, ValueKind};
-use komi_util::Range;
+use komi_syntax::{Ast, Value};
 
 type ResVal = Result<Value, EvalError>;
 
@@ -23,231 +24,7 @@ impl<'a> Evaluator<'a> {
     }
 
     pub fn eval(&self) -> ResVal {
-        Self::eval_ast(self.ast)
-    }
-
-    fn eval_ast(ast: &Ast) -> ResVal {
-        let loc = ast.location;
-        match &ast.kind {
-            AstKind::Program { expressions: e } => Self::evaluate_expressions(&e, &loc),
-            AstKind::Number(x) => Self::evaluate_number(*x, &loc),
-            AstKind::Bool(x) => Self::evaluate_bool(*x, &loc),
-            AstKind::PrefixPlus { operand: op } => Self::evaluate_prefix_plus(&op, &loc),
-            AstKind::PrefixMinus { operand: op } => Self::evaluate_prefix_minus(&op, &loc),
-            AstKind::PrefixBang { operand: op } => Self::evaluate_prefix_bang(&op, &loc),
-            AstKind::InfixPlus { left, right } => Self::eval_infix_plus(&left, &right),
-            AstKind::InfixMinus { left, right } => Self::eval_infix_minus(&left, &right),
-            AstKind::InfixAsterisk { left, right } => Self::eval_infix_asterisk(&left, &right),
-            AstKind::InfixSlash { left, right } => Self::eval_infix_slash(&left, &right),
-            AstKind::InfixPercent { left, right } => Self::eval_infix_percent(&left, &right),
-            AstKind::InfixConjunct { left, right } => Self::eval_infix_conjunct(&left, &right),
-            AstKind::InfixDisjunct { left, right } => Self::eval_infix_disjunct(&left, &right),
-        }
-    }
-
-    /// Returns the evaluated result of the last AST in the ASTs `expressions`.
-    ///
-    /// Sets its location to be `expressions_location`, since it represents the entire expressions, not a single one.
-    fn evaluate_expressions(expressions: &Vec<Box<Ast>>, expressions_location: &Range) -> ResVal {
-        let mut last_value = Value::from_empty(*expressions_location);
-
-        for expression in expressions {
-            last_value = Self::eval_ast(expression)?;
-        }
-        last_value.location = *expressions_location;
-        Ok(last_value)
-    }
-
-    /// Returns the evaluated numeric result, from number `num` and its location `location`.
-    fn evaluate_number(num: f64, location: &Range) -> ResVal {
-        Ok(Value::new(ValueKind::Number(num), *location))
-    }
-
-    /// Returns the evaluated boolean result, from boolean `boolean` and its location `location`.
-    fn evaluate_bool(boolean: bool, location: &Range) -> ResVal {
-        Ok(Value::new(ValueKind::Bool(boolean), *location))
-    }
-
-    /// Returns the evaluated numeric result of the AST `operand` as an operand of the prefix plus.
-    ///
-    /// The location in the returned value will span from the prefix to operand.
-    fn evaluate_prefix_plus(operand: &Ast, prefix_location: &Range) -> ResVal {
-        Self::evaluate_num_prefix(operand, prefix_location, |v| ValueKind::Number(v))
-    }
-
-    /// Returns the evaluated numeric result of the AST `operand` as an operand of the prefix minus.
-    ///
-    /// The location in the returned value will span from the prefix to operand.
-    fn evaluate_prefix_minus(operand: &Ast, prefix_location: &Range) -> ResVal {
-        Self::evaluate_num_prefix(operand, prefix_location, |v| ValueKind::Number(-v))
-    }
-
-    /// Returns the evaluated boolean result of the AST `operand` as an operand of the prefix bang.
-    ///
-    /// The location in the returned value will span from the prefix to operand.
-    fn evaluate_prefix_bang(operand: &Ast, prefix_location: &Range) -> ResVal {
-        Self::evaluate_bool_prefix(operand, prefix_location, |v| ValueKind::Bool(!v))
-    }
-
-    fn eval_infix_plus(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_num_infix(left, right, |l, r| l + r, |v| ValueKind::Number(v))
-    }
-
-    fn eval_infix_minus(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_num_infix(left, right, |l, r| l - r, |v| ValueKind::Number(v))
-    }
-
-    fn eval_infix_asterisk(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_num_infix(left, right, |l, r| l * r, |v| ValueKind::Number(v))
-    }
-
-    fn eval_infix_slash(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_num_infix(left, right, |l, r| l / r, |v| ValueKind::Number(v))
-    }
-
-    fn eval_infix_percent(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_num_infix(left, right, |l, r| l % r, |v| ValueKind::Number(v))
-    }
-
-    fn eval_infix_conjunct(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_bool_infix(left, right, |l, r| l && r, |v| ValueKind::Bool(v))
-    }
-
-    fn eval_infix_disjunct(left: &Ast, right: &Ast) -> ResVal {
-        Self::evaluate_bool_infix(left, right, |l, r| l || r, |v| ValueKind::Bool(v))
-    }
-
-    /// Returns the evaluated numeric result of the AST `operand` as a leaf operand of a prefix.
-    fn evaluate_num_prefix_operand(operand: &Ast) -> Result<f64, EvalError> {
-        Self::evaluate_leaf_operand(operand, |value_kind| match value_kind {
-            ValueKind::Number(x) => Ok(*x),
-            _ => Err(EvalErrorKind::InvalidPrefixNumOperand),
-        })
-    }
-
-    /// Returns the evaluated boolean result of the AST `operand` as a leaf operand of a prefix.
-    fn evaluate_bool_prefix_operand(operand: &Ast) -> Result<bool, EvalError> {
-        Self::evaluate_leaf_operand(operand, |value_kind| match value_kind {
-            ValueKind::Bool(x) => Ok(*x),
-            _ => Err(EvalErrorKind::InvalidPrefixBoolOperand),
-        })
-    }
-
-    /// Returns the evaluated numeric result of the AST `operand` as a leaf operand of an infix.
-    fn evaluate_num_infix_operand(operand: &Ast) -> Result<f64, EvalError> {
-        Self::evaluate_leaf_operand(operand, |value_kind| match value_kind {
-            ValueKind::Number(x) => Ok(*x),
-            _ => Err(EvalErrorKind::InvalidAdditionOperand),
-        })
-    }
-
-    /// Returns the evaluated boolean result of the AST `operand` as a leaf operand of an infix.
-    fn evaluate_bool_infix_operand(operand: &Ast) -> Result<bool, EvalError> {
-        Self::evaluate_leaf_operand(operand, |value_kind| match value_kind {
-            ValueKind::Bool(x) => Ok(*x),
-            _ => Err(EvalErrorKind::InvalidConnectiveInfixOperand),
-        })
-    }
-
-    fn evaluate_num_prefix<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
-    where
-        F: Fn(f64) -> ValueKind,
-    {
-        Self::evaluate_prefix(operand, prefix_location, Self::evaluate_num_prefix_operand, get_kind)
-    }
-
-    fn evaluate_bool_prefix<F>(operand: &Ast, prefix_location: &Range, get_kind: F) -> ResVal
-    where
-        F: Fn(bool) -> ValueKind,
-    {
-        Self::evaluate_prefix::<bool, _, _>(operand, prefix_location, Self::evaluate_bool_prefix_operand, get_kind)
-    }
-
-    /// Returns the evaluated result of the AST `operand` as an operand of a prefix.
-    ///
-    /// - `evaluate_operand` determines how to evaluate the AST `operand` itself to some value `x`.
-    /// - `get_kind` specifies how to get the value kind from `x`.
-    ///
-    /// The location in the returned value will span from the prefix to operand.
-    fn evaluate_prefix<T, F, G>(operand: &Ast, prefix_location: &Range, evaluate_operand: F, get_kind: G) -> ResVal
-    where
-        F: Fn(&Ast) -> Result<T, EvalError>,
-        G: Fn(T) -> ValueKind,
-    {
-        let evaluated_operand = evaluate_operand(operand)?;
-        let kind = get_kind(evaluated_operand);
-        let location = Range::new(prefix_location.begin, operand.location.end);
-        Ok(Value::new(kind, location))
-    }
-
-    fn evaluate_bool_infix<F, G>(left: &Ast, right: &Ast, evaluate_infix: F, make_value_kind: G) -> ResVal
-    where
-        F: Fn(bool, bool) -> bool,
-        G: Fn(bool) -> ValueKind,
-    {
-        Self::evaluate_infix(
-            left,
-            right,
-            Self::evaluate_bool_infix_operand,
-            evaluate_infix,
-            make_value_kind,
-        )
-    }
-
-    fn evaluate_num_infix<F, G>(left: &Ast, right: &Ast, evaluate_infix: F, make_value_kind: G) -> ResVal
-    where
-        F: Fn(f64, f64) -> f64,
-        G: Fn(f64) -> ValueKind,
-    {
-        Self::evaluate_infix(
-            left,
-            right,
-            Self::evaluate_num_infix_operand,
-            evaluate_infix,
-            make_value_kind,
-        )
-    }
-
-    // TODO: document
-    // TODO(?): factor out into separate file
-    fn evaluate_infix<T, F, G, H>(
-        left: &Ast,
-        right: &Ast,
-        evaluate_operand: F,
-        evaluate_infix: G,
-        make_value_kind: H,
-    ) -> ResVal
-    where
-        F: Fn(&Ast) -> Result<T, EvalError>,
-        G: Fn(T, T) -> T,
-        H: Fn(T) -> ValueKind,
-    {
-        let left_val = evaluate_operand(left)?;
-        let right_val = evaluate_operand(right)?;
-
-        let infix_val = evaluate_infix(left_val, right_val);
-
-        let kind = make_value_kind(infix_val);
-        let location = Range::new(left.location.begin, right.location.end);
-
-        Ok(Value::new(kind, location))
-    }
-
-    /// Returns the evalauted result of the AST `operand` as a leaf operand of a prefix or an infix.
-    ///
-    /// `extract` specifies the expected kind `x` of the evaluated result of `operand`.
-    /// - If `x` encountered, it returns `Ok` from `x`.
-    /// - Otherwise, returns `Err(e)` where `e` is `EvalError`.
-    fn evaluate_leaf_operand<T, F>(operand: &Ast, extract: F) -> Result<T, EvalError>
-    where
-        F: Fn(&ValueKind) -> Result<T, EvalErrorKind>,
-    {
-        let val = Self::eval_ast(operand)?;
-
-        match extract(&val.kind) {
-            Ok(x) => Ok(x),
-            Err(kind) => Err(EvalError::new(kind, val.location)),
-        }
+        reduce_ast(self.ast)
     }
 }
 
@@ -258,8 +35,9 @@ pub fn eval(ast: &Ast) -> ResVal {
 
 #[cfg(test)]
 mod tests {
-    use super::{Ast, AstKind, EvalError, EvalErrorKind, Range, Value, ValueKind, eval};
-    use komi_syntax::mkast;
+    use super::{Ast, EvalError, EvalErrorKind, Value, eval};
+    use komi_syntax::{AstKind, ValueKind, mkast};
+    use komi_util::Range;
     use rstest::rstest;
 
     /// Asserts a given AST to be evaluated into the expected value.


### PR DESCRIPTION
simply divided into files

(new) naming convention:
- `reduce` means mapping abstract syntax tree to a value
- `primitive` refers to some value at rust level, not in the value system in the language