### PR TITLE
partially implement identifier lexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,9 @@ dependencies = [
 [[package]]
 name = "komi_util"
 version = "0.0.0-local"
+dependencies = [
+ "rstest",
+]
 
 [[package]]
 name = "komi_wasm"

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -154,7 +154,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn lex_true(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_boolean(true, *first_location))
+        Ok(Token::new(TokenKind::Bool(true), *first_location))
     }
 
     /// Returns a false literal token `거짓` if successfully lexed, or error otherwise.
@@ -169,39 +169,39 @@ impl<'a> Lexer<'a> {
         let location = Range::new(first_location.begin, self.scanner.locate().end);
         self.scanner.advance();
 
-        Ok(Token::from_boolean(false, location))
+        Ok(Token::new(TokenKind::Bool(false), location))
     }
 
     fn lex_plus(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_plus(*first_location))
+        Ok(Token::new(TokenKind::Plus, *first_location))
     }
 
     fn lex_minus(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_minus(*first_location))
+        Ok(Token::new(TokenKind::Minus, *first_location))
     }
 
     fn lex_asterisk(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_asterisk(*first_location))
+        Ok(Token::new(TokenKind::Asterisk, *first_location))
     }
 
     fn lex_slash(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_slash(*first_location))
+        Ok(Token::new(TokenKind::Slash, *first_location))
     }
 
     fn lex_percent(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_percent(*first_location))
+        Ok(Token::new(TokenKind::Percent, *first_location))
     }
 
     fn lex_lparen(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_lparen(*first_location))
+        Ok(Token::new(TokenKind::LParen, *first_location))
     }
 
     fn lex_rparen(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_rparen(*first_location))
+        Ok(Token::new(TokenKind::RParen, *first_location))
     }
 
     fn lex_bang(&mut self, first_location: &Range) -> ResToken {
-        Ok(Token::from_bang(*first_location))
+        Ok(Token::new(TokenKind::Bang, *first_location))
     }
 
     /// Returns a conjunction token `그리고` if successfully lexed, or error otherwise.
@@ -253,7 +253,7 @@ impl<'a> Lexer<'a> {
     fn parse_num_lexeme(lexeme: &String, location: Range) -> Token {
         let num = lexeme.parse::<f64>().unwrap();
 
-        Token::from_num(num, location)
+        Token::new(TokenKind::Number(num), location)
     }
 
     fn read_digits(&mut self, first_char: &'a str) -> String {

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -10,7 +10,7 @@ mod utf8_tape;
 pub use err::{LexError, LexErrorKind};
 use komi_syntax::{Token, TokenKind};
 use komi_util::string;
-use komi_util::{Range, Scanner};
+use komi_util::{Range, Scanner, Spot};
 use source_scanner::SourceScanner;
 
 type ResTokens = Result<Vec<Token>, LexError>;
@@ -39,13 +39,23 @@ impl<'a> Lexer<'a> {
         Self { scanner: SourceScanner::new(source) }
     }
 
+    // TODO: replace locate and advance logic with this, to force marking the previous location.
+    fn locate_and_advance(&mut self) -> Range {
+        let location = self.scanner.locate();
+        self.scanner.advance();
+
+        location
+    }
+
     pub fn lex(&mut self) -> ResTokens {
         let mut tokens: Vec<Token> = vec![];
 
-        while let Some(x) = self.scanner.read() {
-            match x {
-                x if string::is_digit(x) => {
-                    let token = advance_and_lex!(self, Self::lex_num, x)?;
+        while let Some(first_char) = self.scanner.read() {
+            let first_location = &self.scanner.locate();
+
+            match first_char {
+                first_char if string::is_digit(first_char) => {
+                    let token = advance_and_lex!(self, Self::lex_num, first_char)?;
                     tokens.push(token);
                 }
                 "참" => {
@@ -53,7 +63,48 @@ impl<'a> Lexer<'a> {
                     tokens.push(token);
                 }
                 "거" => {
-                    let token = advance_and_lex!(self, Self::lex_false)?;
+                    // TODO: move this advance out of while above.
+                    //       you should replace advance_and_lex! macros with lower level operations.
+                    self.scanner.advance();
+
+                    let second_char = self.scanner.read();
+                    if second_char.is_none_or(|c| !string::is_id_domain(c)) {
+                        let lexeme = String::from(first_char);
+                        let location = Range::new(first_location.begin, first_location.end);
+                        let token = Token::new(TokenKind::Identifier(lexeme), location);
+                        tokens.push(token);
+
+                        continue;
+                    } else if second_char.is_some_and(|c| string::is_id_domain(c) && c != "짓") {
+                        let init_seg_end = self.scanner.locate().end;
+                        self.scanner.advance();
+
+                        let init_seg = String::from(first_char) + second_char.unwrap();
+                        let token =
+                            self.lex_identifier_with_init_seg(&first_location.begin, &init_seg, &init_seg_end)?;
+                        tokens.push(token);
+
+                        continue;
+                    }
+
+                    let second_location = &self.scanner.locate();
+                    self.scanner.advance();
+
+                    let third_char = self.scanner.read();
+                    if third_char.is_some_and(string::is_id_domain) {
+                        let init_seg_end = self.scanner.locate().end;
+                        self.scanner.advance();
+
+                        let init_seg = String::from(first_char) + second_char.unwrap() + third_char.unwrap();
+                        let token =
+                            self.lex_identifier_with_init_seg(&first_location.begin, &init_seg, &init_seg_end)?;
+                        tokens.push(token);
+
+                        continue;
+                    }
+
+                    let location = Range::new(first_location.begin, second_location.end);
+                    let token = Token::new(TokenKind::Bool(false), location);
                     tokens.push(token);
                 }
                 "+" => {
@@ -93,7 +144,7 @@ impl<'a> Lexer<'a> {
                     tokens.push(token);
                 }
                 "또" => {
-                    let token = advance_and_lex!(self, Self::lex_disjunct)?;
+                    let token = advance_and_lex!(self, Self::lex_disjunct_or_identifier)?;
                     tokens.push(token);
                 }
                 "#" => {
@@ -101,6 +152,10 @@ impl<'a> Lexer<'a> {
                     self.skip_comment();
                 }
                 s if string::is_whitespace(s) => self.scanner.advance(),
+                s if string::is_id_domain(s) => {
+                    let token = self.lex_identifier(&self.scanner.locate(), &String::new())?;
+                    tokens.push(token);
+                }
                 _ => {
                     return Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()));
                 }
@@ -160,16 +215,67 @@ impl<'a> Lexer<'a> {
     /// Returns a false literal token `거짓` if successfully lexed, or error otherwise.
     ///
     /// Call after advancing the scanner `self.scanner` past the initial character `거`, with its location passed as `first_location`.
-    fn lex_false(&mut self, first_location: &Range) -> ResToken {
-        let Some("짓") = self.scanner.read() else {
-            // TODO: return an identifier token, when the identifier token is implemented.
-            return Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()));
-        };
+    fn lex_false_or_identifier(&mut self, first_location: &Range) -> ResToken {
+        match self.scanner.read() {
+            Some("짓") => {
+                let location = Range::new(first_location.begin, self.scanner.locate().end);
+                self.scanner.advance();
+
+                Ok(Token::new(TokenKind::Bool(false), location))
+            }
+            Some(x) if string::is_id_domain(x) => {
+                let begin_chars = String::from("거") + x;
+                self.scanner.advance();
+                let token = self.lex_identifier(first_location, &begin_chars)?;
+
+                Ok(token)
+            }
+            Some(x) if !string::is_whitespace(x) => {
+                Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()))
+            }
+            _ => {
+                // For whitespace or None
+                let token = Token::new(TokenKind::Identifier(String::from("거")), *first_location);
+
+                Ok(token)
+            }
+        }
+    }
+
+    fn lex_identifier_with_init_seg(&mut self, lexeme_begin: &Spot, init_seg: &str, init_seg_end: &Spot) -> ResToken {
+        let mut lexeme = String::from(init_seg);
+        let mut lexeme_end = *init_seg_end;
+
+        while let Some(x) = self.scanner.read() {
+            if !string::is_id_domain(x) {
+                break;
+            }
+
+            lexeme.push_str(x);
+            lexeme_end = self.scanner.locate().end;
+
+            self.scanner.advance();
+        }
+
+        let location = Range::new(*lexeme_begin, lexeme_end);
+        Ok(Token::new(TokenKind::Identifier(lexeme), location))
+    }
+
+    fn lex_identifier(&mut self, first_location: &Range, begin_chars: &str) -> ResToken {
+        let mut lexeme = String::from(begin_chars);
+
+        while let Some(x) = self.scanner.read() {
+            if !string::is_id_domain(x) {
+                break;
+            }
+
+            lexeme.push_str(x);
+
+            self.scanner.advance();
+        }
 
         let location = Range::new(first_location.begin, self.scanner.locate().end);
-        self.scanner.advance();
-
-        Ok(Token::new(TokenKind::Bool(false), location))
+        Ok(Token::new(TokenKind::Identifier(lexeme), location))
     }
 
     fn lex_plus(&mut self, first_location: &Range) -> ResToken {
@@ -229,15 +335,31 @@ impl<'a> Lexer<'a> {
     /// Returns a conjunction token `또는` if successfully lexed, or error otherwise.
     ///
     /// Call after advancing the scanner `self.scanner` past the initial character `또`, with its location passed as `first_location`.
-    fn lex_disjunct(&mut self, first_location: &Range) -> ResToken {
-        let Some("는") = self.scanner.read() else {
-            return Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()));
-        };
+    fn lex_disjunct_or_identifier(&mut self, first_location: &Range) -> ResToken {
+        match self.scanner.read() {
+            Some("는") => {
+                let location = Range::new(first_location.begin, self.scanner.locate().end);
+                self.scanner.advance();
 
-        let location = Range::new(first_location.begin, self.scanner.locate().end);
-        self.scanner.advance();
+                Ok(Token::new(TokenKind::Disjunct, location))
+            }
+            Some(x) if komi_util::string::is_id_domain(x) => {
+                let begin_chars = String::from("또") + x;
+                self.scanner.advance();
+                let token = self.lex_identifier(first_location, &begin_chars)?;
 
-        Ok(Token::new(TokenKind::Disjunct, location))
+                Ok(token)
+            }
+            Some(x) if !string::is_whitespace(x) => {
+                Err(LexError::new(LexErrorKind::IllegalChar, self.scanner.locate()))
+            }
+            _ => {
+                // For whitespace or None
+                let token = Token::new(TokenKind::Identifier(String::from("또")), *first_location);
+
+                Ok(token)
+            }
+        }
     }
 
     fn skip_comment(&mut self) -> () {
@@ -355,9 +477,23 @@ mod tests {
     #[case::lparen("(", vec![mktoken!(TokenKind::LParen, loc 0, 0, 0, 1)])]
     #[case::rparen(")", vec![mktoken!(TokenKind::RParen, loc 0, 0, 0, 1)])]
     #[case::bang("!", vec![mktoken!(TokenKind::Bang, loc 0, 0, 0, 1)])]
-    #[case::bang("그리고", vec![mktoken!(TokenKind::Conjunct, loc 0, 0, 0, 3)])]
-    #[case::bang("또는", vec![mktoken!(TokenKind::Disjunct, loc 0, 0, 0, 2)])]
+    #[case::conjunct("그리고", vec![mktoken!(TokenKind::Conjunct, loc 0, 0, 0, 3)])]
+    #[case::disjunct("또는", vec![mktoken!(TokenKind::Disjunct, loc 0, 0, 0, 2)])]
     fn single_token(#[case] source: &str, #[case] expected: Vec<Token>) {
+        assert_lex!(source, expected);
+    }
+
+    #[rstest]
+    #[case::single_alphabat_char("a", vec![mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1)])]
+    #[case::single_hangul_char("가", vec![mktoken!(TokenKind::Identifier(String::from("가")), loc 0, 0, 0, 1)])]
+    #[case::first_char_false_but_end("거", vec![mktoken!(TokenKind::Identifier(String::from("거")), loc 0, 0, 0, 1)])]
+    #[case::first_char_false_but_second_non_id("거 ", vec![mktoken!(TokenKind::Identifier(String::from("거")), loc 0, 0, 0, 1)])]
+    #[case::first_char_false_but_second_other_id("거짔", vec![mktoken!(TokenKind::Identifier(String::from("거짔")), loc 0, 0, 0, 2)])]
+    #[case::first_two_chars_false_but_not_third("거짓a", vec![mktoken!(TokenKind::Identifier(String::from("거짓a")), loc 0, 0, 0, 3)])]
+    #[case::first_char_disjunct_but_end("또", vec![mktoken!(TokenKind::Identifier(String::from("또")), loc 0, 0, 0, 1)])]
+    #[case::first_char_disjunct_but_not_second("또늗", vec![mktoken!(TokenKind::Identifier(String::from("또늗")), loc 0, 0, 0, 2)])]
+    // TODO: add first_two_chars_disjuct_but_not_third
+    fn single_identifier(#[case] source: &str, #[case] expected: Vec<Token>) {
         assert_lex!(source, expected);
     }
 
@@ -371,6 +507,22 @@ mod tests {
         mktoken!(TokenKind::Number(12.0), loc 0, 0, 0, "12".len()),
         mktoken!(TokenKind::Plus, loc 0, "12 ".len(), 0, "12 +".len()),
         mktoken!(TokenKind::Number(34.675), loc 0, "12 + ".len(), 0, "12 + 34.675".len()),
+    ])]
+    #[case::false_false("거짓 거짓", vec![
+        mktoken!(TokenKind::Bool(false), loc 0, 0, 0, 2),
+        mktoken!(TokenKind::Bool(false), loc 0, 3, 0, 5),
+    ])]
+    #[case::id1_false("거 거짓", vec![
+        mktoken!(TokenKind::Identifier(String::from("거")), loc 0, 0, 0, 1),
+        mktoken!(TokenKind::Bool(false), loc 0, 2, 0, 4),
+    ])]
+    #[case::id2_false("거짔 거짓", vec![
+        mktoken!(TokenKind::Identifier(String::from("거짔")), loc 0, 0, 0, 2),
+        mktoken!(TokenKind::Bool(false), loc 0, 3, 0, 5),
+    ])]
+    #[case::id3_false("거짓a 거짓", vec![
+        mktoken!(TokenKind::Identifier(String::from("거짓a")), loc 0, 0, 0, 3),
+        mktoken!(TokenKind::Bool(false), loc 0, 4, 0, 6),
     ])]
     fn multiple_tokens(#[case] source: &str, #[case] expected: Vec<Token>) {
         assert_lex!(source, expected);

--- a/komi_parser/src/token_scanner/mod.rs
+++ b/komi_parser/src/token_scanner/mod.rs
@@ -50,15 +50,9 @@ impl<'a> Scanner for TokenScanner<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fixtures::*;
     use komi_syntax::TokenKind;
     use komi_util::Range;
-
-    const RANGE_MOCKS: &[Range] = &[Range::from_nums(0, 0, 0, 1), Range::from_nums(0, 1, 0, 2)];
-    const TOKEN_KIND_MOCKS: &[TokenKind] = &[TokenKind::Number(1.0), TokenKind::Number(2.0)];
-    const TOKEN_MOCKS: &[Token] = &[
-        Token::new(TOKEN_KIND_MOCKS[0], RANGE_MOCKS[0]),
-        Token::new(TOKEN_KIND_MOCKS[1], RANGE_MOCKS[1]),
-    ];
 
     #[test]
     fn test_read_for_empty() {
@@ -71,22 +65,22 @@ mod tests {
 
     #[test]
     fn test_read_twice() {
-        let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
+        let tokens = vec![token1(), token2()];
 
         let scanner = TokenScanner::new(&tokens);
 
-        assert_eq!(scanner.read(), Some(&TOKEN_MOCKS[0]));
-        assert_eq!(scanner.read(), Some(&TOKEN_MOCKS[0]));
+        assert_eq!(scanner.read(), Some(&token1()));
+        assert_eq!(scanner.read(), Some(&token1()));
     }
 
     #[test]
     fn test_advance() {
-        let tokens = vec![TOKEN_MOCKS[0], TOKEN_MOCKS[1]];
+        let tokens = vec![token1(), token2()];
 
         let mut scanner = TokenScanner::new(&tokens);
 
         scanner.advance();
-        assert_eq!(scanner.read(), Some(&TOKEN_MOCKS[1]));
+        assert_eq!(scanner.read(), Some(&token2()));
     }
 
     #[test]
@@ -102,8 +96,8 @@ mod tests {
     #[test]
     fn test_locate() {
         let tokens = vec![
-            Token::new(TOKEN_KIND_MOCKS[0], Range::from_nums(0, 0, 0, 2)),
-            Token::new(TOKEN_KIND_MOCKS[1], Range::from_nums(0, 2, 0, 5)),
+            Token::new(token_kind1(), Range::from_nums(0, 0, 0, 2)),
+            Token::new(token_kind2(), Range::from_nums(0, 2, 0, 5)),
         ];
 
         let mut scanner = TokenScanner::new(&tokens);
@@ -124,5 +118,28 @@ mod tests {
         assert_eq!(scanner.locate(), range::ORIGIN);
         scanner.advance();
         assert_eq!(scanner.locate(), range::ORIGIN);
+    }
+
+    mod fixtures {
+        use super::*;
+
+        pub fn range1() -> Range {
+            Range::from_nums(0, 0, 0, 1)
+        }
+        pub fn range2() -> Range {
+            Range::from_nums(0, 1, 0, 2)
+        }
+        pub fn token_kind1() -> TokenKind {
+            TokenKind::Number(1.0)
+        }
+        pub fn token_kind2() -> TokenKind {
+            TokenKind::Number(2.0)
+        }
+        pub fn token1() -> Token {
+            Token::new(token_kind1(), range1())
+        }
+        pub fn token2() -> Token {
+            Token::new(token_kind2(), range2())
+        }
     }
 }

--- a/komi_syntax/src/token/mod.rs
+++ b/komi_syntax/src/token/mod.rs
@@ -53,47 +53,6 @@ impl Token {
     pub const fn new(kind: TokenKind, location: Range) -> Self {
         Token { kind, location }
     }
-
-    // TODO: really need to use `from_*()` functions, instead of `new()`??
-    pub const fn from_num(num: f64, location: Range) -> Self {
-        Token::new(TokenKind::Number(num), location)
-    }
-
-    pub const fn from_boolean(boolean: bool, location: Range) -> Self {
-        Token::new(TokenKind::Bool(boolean), location)
-    }
-
-    pub const fn from_plus(location: Range) -> Self {
-        Token::new(TokenKind::Plus, location)
-    }
-
-    pub const fn from_minus(location: Range) -> Self {
-        Token::new(TokenKind::Minus, location)
-    }
-
-    pub const fn from_asterisk(location: Range) -> Self {
-        Token::new(TokenKind::Asterisk, location)
-    }
-
-    pub const fn from_slash(location: Range) -> Self {
-        Token::new(TokenKind::Slash, location)
-    }
-
-    pub const fn from_percent(location: Range) -> Self {
-        Token::new(TokenKind::Percent, location)
-    }
-
-    pub const fn from_lparen(location: Range) -> Self {
-        Token::new(TokenKind::LParen, location)
-    }
-
-    pub const fn from_rparen(location: Range) -> Self {
-        Token::new(TokenKind::RParen, location)
-    }
-
-    pub const fn from_bang(location: Range) -> Self {
-        Token::new(TokenKind::Bang, location)
-    }
 }
 
 /// Makes a token with the kind and the location specified by four numbers.
@@ -119,75 +78,5 @@ mod tests {
         let token = Token::new(TokenKind::Number(1.0), RANGE_MOCK);
 
         assert_eq!(token, Token { kind: TokenKind::Number(1.0), location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_num() {
-        let token = Token::from_num(1.0, RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Number(1.0), location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_boolean() {
-        let token = Token::from_boolean(true, RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Bool(true), location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_plus() {
-        let token = Token::from_plus(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Plus, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_minus() {
-        let token = Token::from_minus(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Minus, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_asterisk() {
-        let token = Token::from_asterisk(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Asterisk, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_slash() {
-        let token = Token::from_slash(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Slash, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_percent() {
-        let token = Token::from_percent(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Percent, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_lparen() {
-        let token = Token::from_lparen(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::LParen, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_rparen() {
-        let token = Token::from_rparen(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::RParen, location: RANGE_MOCK })
-    }
-
-    #[test]
-    fn test_from_bang() {
-        let token = Token::from_bang(RANGE_MOCK);
-
-        assert_eq!(token, Token { kind: TokenKind::Bang, location: RANGE_MOCK })
     }
 }

--- a/komi_syntax/src/token/mod.rs
+++ b/komi_syntax/src/token/mod.rs
@@ -28,6 +28,18 @@ pub enum TokenKind {
     Conjunct,
     /// A disjunction `또는`.
     Disjunct,
+    /// An equals `=`.
+    Equals,
+    /// A plus-equals `+=`,
+    PlusEquals,
+    /// A minus-equals `-=`.
+    MinusEquals,
+    /// A asterisk-equals `*=`.
+    AsteriskEquals,
+    /// A slash-equals `/=`.
+    SlashEquals,
+    /// A percent-equals `%=`.
+    PercentEquals,
 }
 
 /// A token produced during lexing.

--- a/komi_syntax/src/token/mod.rs
+++ b/komi_syntax/src/token/mod.rs
@@ -2,12 +2,14 @@ use komi_util::Range;
 
 /// Kinds of tokens produced during lexing.
 /// Serves as the interface between a lexer and its user.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TokenKind {
     /// A number with or without decimal, such as `12` or `12.25`.
     Number(f64),
     /// A boolean `참` or `거짓`.
     Bool(bool),
+    /// An identifier, such as `사과` or `오렌지`.
+    Identifier(String),
     /// A plus `+`.
     Plus,
     /// A minus `-`.
@@ -43,7 +45,7 @@ pub enum TokenKind {
 }
 
 /// A token produced during lexing.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Token {
     pub kind: TokenKind,
     pub location: Range,

--- a/komi_util/Cargo.toml
+++ b/komi_util/Cargo.toml
@@ -5,3 +5,6 @@ publish = false
 edition = "2024"
 
 [dependencies]
+
+[dev-dependencies]
+rstest = "0.25.0"

--- a/komi_util/src/string/mod.rs
+++ b/komi_util/src/string/mod.rs
@@ -5,3 +5,87 @@ pub fn is_digit(s: &str) -> bool {
 pub fn is_whitespace(s: &str) -> bool {
     (s.len() == 1 && s.chars().next().unwrap().is_ascii_whitespace()) || (s == "\r\n")
 }
+
+/// Returns true if the given string `s` is a character within the identifier domain; false otherwise.
+///
+/// The identifier domain is a set of characters that the lexer recognizes as valid for identifiers.
+/// Specifically, it includes:
+/// - ASCII alphabets and number characters.
+/// - Hangul, from `U+AC00` (`가`) to `U+D7A3` (`힣`)
+pub fn is_identifier_domain(s: &str) -> bool {
+    let ascii = s.len() == 1 && s.chars().next().unwrap().is_ascii_alphanumeric();
+    if ascii {
+        return true;
+    }
+    let hangul = s.len() == 3 && is_hangul_identifier_domain(s.chars().next().unwrap());
+    if hangul {
+        return true;
+    }
+
+    false
+}
+
+/// Returns true if the given character is within the Unicode range for Hangul (from `U+AC00` to `U+D7AC`); false otherwise.
+fn is_hangul_identifier_domain(c: char) -> bool {
+    let u = u32::from(c);
+    0xAC00 <= u && u <= 0xD7A3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::digit("1", true)]
+    #[case::two_digits("12", false)]
+    #[case::non_digit("x", false)]
+    fn test_is_digit(#[case] s: &str, #[case] expected: bool) {
+        assert_eq!(is_digit(s), expected);
+    }
+
+    #[rstest]
+    #[case::digit("1", false)]
+    #[case::space(" ", true)]
+    #[case::two_spaces("  ", false)]
+    #[case::cr("\r", true)]
+    #[case::lf("\n", true)]
+    #[case::crlf("\r\n", true)]
+    #[case::crcr("\r\r", false)]
+    #[case::lflf("\n\n", false)]
+    #[case::crlfcrlf("\r\n\r\n", false)]
+    fn test_is_whitespace(#[case] s: &str, #[case] expected: bool) {
+        assert_eq!(is_whitespace(s), expected);
+    }
+
+    #[rstest]
+    #[case::hangul_ga("가", true)]
+    #[case::hangul_na("나", true)]
+    #[case::hangul_da("다", true)]
+    #[case::hangul_hit("힣", true)]
+    #[case::numeric("1", true)]
+    #[case::alphabet("a", true)]
+    #[case::two_hanguls("가나", false)]
+    #[case::space(" ", false)]
+    #[case::cr("\r", false)]
+    #[case::lf("\n", false)]
+    #[case::crlf("\r\n", false)]
+    #[case::below_hangul_boundary(&String::from(char::from_u32(0xD7A4).unwrap()), false)]
+    #[case::above_hangul_boundary(&String::from(char::from_u32(0xD7A4).unwrap()), false)]
+    fn test_is_identifier_domain(#[case] s: &str, #[case] expected: bool) {
+        assert_eq!(is_identifier_domain(s), expected);
+    }
+
+    #[rstest]
+    #[case::hangul_ga('가', true)]
+    #[case::hangul_na('나', true)]
+    #[case::hangul_da('다', true)]
+    #[case::hangul_hit('힣', true)]
+    #[case::numeric('1', false)]
+    #[case::alphabet('a', false)]
+    #[case::below_hangul_boundary(char::from_u32(0xD7A4).unwrap(), false)]
+    #[case::above_hangul_boundary(char::from_u32(0xD7A4).unwrap(), false)]
+    fn test_is_hangul_identifier_domain(#[case] c: char, #[case] expected: bool) {
+        assert_eq!(is_hangul_identifier_domain(c), expected);
+    }
+}

--- a/komi_util/src/string/mod.rs
+++ b/komi_util/src/string/mod.rs
@@ -12,7 +12,7 @@ pub fn is_whitespace(s: &str) -> bool {
 /// Specifically, it includes:
 /// - ASCII alphabets and number characters.
 /// - Hangul, from `U+AC00` (`가`) to `U+D7A3` (`힣`)
-pub fn is_identifier_domain(s: &str) -> bool {
+pub fn is_id_domain(s: &str) -> bool {
     let ascii = s.len() == 1 && s.chars().next().unwrap().is_ascii_alphanumeric();
     if ascii {
         return true;
@@ -72,8 +72,8 @@ mod tests {
     #[case::crlf("\r\n", false)]
     #[case::below_hangul_boundary(&String::from(char::from_u32(0xD7A4).unwrap()), false)]
     #[case::above_hangul_boundary(&String::from(char::from_u32(0xD7A4).unwrap()), false)]
-    fn test_is_identifier_domain(#[case] s: &str, #[case] expected: bool) {
-        assert_eq!(is_identifier_domain(s), expected);
+    fn test_is_id_domain(#[case] s: &str, #[case] expected: bool) {
+        assert_eq!(is_id_domain(s), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
feat:
- lex identifier if clear such as `가`
- lex identifier if recognized as identifier during lexing the false, such as `거` ,`거짔`, `거짓a`.

tasks to do
- need better lexing logic: found lexing logic getting complicated than expected (as you can see in this pr), since it is not enough to use simply nested `match`es. (or just i'm poor at rust)
- refactoring required: the complicated patterns expected to emerge in lexing logic for other tokens like `그리고`, `또는`.
- macro is bad: found a macro isn't a good way to refactor the code, because it just expands codes on build. note that it is important for the code to get reasonably shortened (on build) to reduce the bundled size of build artifact.