### PR TITLE
parse equals

### DIFF
--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -34,6 +34,7 @@ pub fn reduce_ast(ast: &Ast, env: &mut Environment) -> ResVal {
         AstKind::InfixConjunct { left: l, right: r } => combinator_infix::reduce_conjunct(&l, &r, &loc, env),
         AstKind::InfixDisjunct { left: l, right: r } => combinator_infix::reduce_disjunct(&l, &r, &loc, env),
         AstKind::InfixEquals { left: l, right: r } => assignment_infix::reduce_equals(&l, &r, &loc, env),
+        _ => todo!(),
     }
 }
 

--- a/komi_lexer/src/source_scanner/mod.rs
+++ b/komi_lexer/src/source_scanner/mod.rs
@@ -20,7 +20,7 @@ impl<'a> Scanner for SourceScanner<'a> {
 
     /// Reads next character unit.
     /// Note that if CRLF (`"\r\n"`) encountered, returned as a unit.
-    fn read(&self) -> Option<&'a str> {
+    fn read(&self) -> Self::Item {
         match self.tape.get_current() {
             Some("\r") => match self.tape.peek_next() {
                 Some("\n") => Some("\r\n"),

--- a/komi_parser/src/lib.rs
+++ b/komi_parser/src/lib.rs
@@ -18,6 +18,12 @@ struct Parser<'a> {
     scanner: TokenScanner<'a>,
 }
 
+macro_rules! mkinfix {
+    ($kind:ident) => {
+        |left, right| AstKind::$kind { left, right }
+    };
+}
+
 impl<'a> Parser<'a> {
     pub fn new(tokens: &'a Vec<Token>) -> Self {
         Self { scanner: TokenScanner::new(tokens) }
@@ -109,14 +115,19 @@ impl<'a> Parser<'a> {
     fn parse_infix_expression(&mut self, left: Box<Ast>, infix: &'a Token) -> ResAst {
         // Determine the AST kind by `get_kind` and the binding power of the infix by `bp`.
         let (get_kind, bp): (fn(Box<Ast>, Box<Ast>) -> AstKind, &Bp) = match infix.kind {
-            TokenKind::Plus => (|l, r| AstKind::InfixPlus { left: l, right: r }, &Bp::ADDITIVE),
-            TokenKind::Minus => (|l, r| AstKind::InfixMinus { left: l, right: r }, &Bp::ADDITIVE),
-            TokenKind::Asterisk => (|l, r| AstKind::InfixAsterisk { left: l, right: r }, &Bp::MULTIPLICATIVE),
-            TokenKind::Slash => (|l, r| AstKind::InfixSlash { left: l, right: r }, &Bp::MULTIPLICATIVE),
-            TokenKind::Percent => (|l, r| AstKind::InfixPercent { left: l, right: r }, &Bp::MULTIPLICATIVE),
-            TokenKind::Conjunct => (|l, r| AstKind::InfixConjunct { left: l, right: r }, &Bp::CONNECTIVE),
-            TokenKind::Disjunct => (|l, r| AstKind::InfixDisjunct { left: l, right: r }, &Bp::CONNECTIVE),
-            TokenKind::Equals => (|l, r| AstKind::InfixEquals { left: l, right: r }, &Bp::ASSIGNMENT),
+            TokenKind::Plus => (mkinfix!(InfixPlus), &Bp::ADDITIVE),
+            TokenKind::Minus => (mkinfix!(InfixMinus), &Bp::ADDITIVE),
+            TokenKind::Asterisk => (mkinfix!(InfixAsterisk), &Bp::MULTIPLICATIVE),
+            TokenKind::Slash => (mkinfix!(InfixSlash), &Bp::MULTIPLICATIVE),
+            TokenKind::Percent => (mkinfix!(InfixPercent), &Bp::MULTIPLICATIVE),
+            TokenKind::Conjunct => (mkinfix!(InfixConjunct), &Bp::CONNECTIVE),
+            TokenKind::Disjunct => (mkinfix!(InfixDisjunct), &Bp::CONNECTIVE),
+            TokenKind::Equals => (mkinfix!(InfixEquals), &Bp::ASSIGNMENT),
+            TokenKind::PlusEquals => (mkinfix!(InfixPlusEquals), &Bp::ASSIGNMENT),
+            TokenKind::MinusEquals => (mkinfix!(InfixMinusEquals), &Bp::ASSIGNMENT),
+            TokenKind::AsteriskEquals => (mkinfix!(InfixAsteriskEquals), &Bp::ASSIGNMENT),
+            TokenKind::SlashEquals => (mkinfix!(InfixSlashEquals), &Bp::ASSIGNMENT),
+            TokenKind::PercentEquals => (mkinfix!(InfixPercentEquals), &Bp::ASSIGNMENT),
             _ => panic!("todo"), // NOTE: this undetermined cases came from calling of the parse_expression(), and bp says nothing about the token kinds explicitly
         };
         self.read_right_and_make_infix_ast(left, bp, get_kind)

--- a/komi_parser/src/lib.rs
+++ b/komi_parser/src/lib.rs
@@ -460,6 +460,76 @@ mod tests {
             ),
         ])
     )]
+    #[case::plus_equals(
+        // Represents `a += 1`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::PlusEquals, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixPlusEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(num 1.0, loc 0, 4, 0, 5),
+            ),
+        ])
+    )]
+    #[case::minus_equals(
+        // Represents `a -= 1`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::MinusEquals, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixMinusEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(num 1.0, loc 0, 4, 0, 5),
+            ),
+        ])
+    )]
+    #[case::asterisk_equals(
+        // Represents `a *= 1`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::AsteriskEquals, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixAsteriskEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(num 1.0, loc 0, 4, 0, 5),
+            ),
+        ])
+    )]
+    #[case::slash_equals(
+        // Represents `a /= 1`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::SlashEquals, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixSlashEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(num 1.0, loc 0, 4, 0, 5),
+            ),
+        ])
+    )]
+    #[case::percent_equals(
+        // Represents `a %= 1`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::PercentEquals, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixPercentEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(num 1.0, loc 0, 4, 0, 5),
+            ),
+        ])
+    )]
     fn infix(#[case] tokens: Vec<Token>, #[case] expected: Box<Ast>) {
         assert_parse!(&tokens, expected);
     }
@@ -502,6 +572,54 @@ mod tests {
         vec![
             mktoken!(TokenKind::Conjunct, loc 0, 0, 0, 2),
             mktoken!(TokenKind::Bool(true), loc 0, 3, 0, 4),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::equals_without_left(
+        // Represents `=1`.
+        vec![
+            mktoken!(TokenKind::Equals, loc 0, 0, 0, 1),
+            mktoken!(TokenKind::Number(1.0), loc 0, 1, 0, 2),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 1))
+    )]
+    #[case::plus_equals_without_left(
+        // Represents `+=1`.
+        vec![
+            mktoken!(TokenKind::PlusEquals, loc 0, 0, 0, 2),
+            mktoken!(TokenKind::Number(1.0), loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::minus_equals_without_left(
+        // Represents `-=1`.
+        vec![
+            mktoken!(TokenKind::MinusEquals, loc 0, 0, 0, 2),
+            mktoken!(TokenKind::Number(1.0), loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::asterisk_equals_without_left(
+        // Represents `*=1`.
+        vec![
+            mktoken!(TokenKind::AsteriskEquals, loc 0, 0, 0, 2),
+            mktoken!(TokenKind::Number(1.0), loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::slash_equals_without_left(
+        // Represents `/=1`.
+        vec![
+            mktoken!(TokenKind::SlashEquals, loc 0, 0, 0, 2),
+            mktoken!(TokenKind::Number(1.0), loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::percent_equals_without_left(
+        // Represents `%=1`.
+        vec![
+            mktoken!(TokenKind::PercentEquals, loc 0, 0, 0, 2),
+            mktoken!(TokenKind::Number(1.0), loc 0, 2, 0, 3),
         ],
         ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
     )]
@@ -566,6 +684,54 @@ mod tests {
         ],
         ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 4))
     )]
+    #[case::equals_without_right(
+        // Represents `a=`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::Equals, loc 0, 1, 0, 2),
+        ],
+        ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::plus_equals_without_right(
+        // Represents `a+=`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::PlusEquals, loc 0, 1, 0, 2),
+        ],
+        ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::minus_equals_without_right(
+        // Represents `a-=`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::MinusEquals, loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 3))
+    )]
+    #[case::asterisk_equals_without_right(
+        // Represents `a*=`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::AsteriskEquals, loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 3))
+    )]
+    #[case::slash_equals_without_right(
+        // Represents `a/=`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::SlashEquals, loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 3))
+    )]
+    #[case::percent_equals_without_right(
+        // Represents `a%=`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::PercentEquals, loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::NoInfixRightOperand, Range::from_nums(0, 0, 0, 3))
+    )]
     fn infix_no_right_operand(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
         assert_parse_fail!(&tokens, error);
     }
@@ -609,6 +775,36 @@ mod tests {
     #[case::disjunct(
         // Represents `또는`.
         vec![mktoken!(TokenKind::Disjunct, loc 0, 0, 0, 2)],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::equals(
+        // Represents `=`.
+        vec![mktoken!(TokenKind::Equals, loc 0, 0, 0, 1)],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 1))
+    )]
+    #[case::plus_equals(
+        // Represents `+=`.
+        vec![mktoken!(TokenKind::PlusEquals, loc 0, 0, 0, 2)],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::minus_equals(
+        // Represents `-=`.
+        vec![mktoken!(TokenKind::MinusEquals, loc 0, 0, 0, 2)],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::asterisk_equals(
+        // Represents `*=`.
+        vec![mktoken!(TokenKind::AsteriskEquals, loc 0, 0, 0, 2)],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::slash_equals(
+        // Represents `/=`.
+        vec![mktoken!(TokenKind::SlashEquals, loc 0, 0, 0, 2)],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
+    )]
+    #[case::percent_equals(
+        // Represents `%=`.
+        vec![mktoken!(TokenKind::PercentEquals, loc 0, 0, 0, 2)],
         ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 0, 0, 2))
     )]
     fn single_token(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
@@ -769,6 +965,125 @@ mod tests {
     }
 
     #[rstest]
+    #[case::two_equals(
+        // Represents `a=b=c`, and expects to be parsed into `a=(b=c)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::Equals, loc 0, 1, 0, 2),
+            mktoken!(TokenKind::Identifier(String::from("b")), loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Equals, loc 0, 3, 0, 4),
+            mktoken!(TokenKind::Identifier(String::from("c")), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixEquals, loc 0, 2, 0, 5,
+                    left mkast!(identifier "b", loc 0, 2, 0, 3),
+                    right mkast!(identifier "c", loc 0, 4, 0, 5),
+                ),
+            ),
+        ])
+    )]
+    #[case::two_plus_equals(
+        // Represents `a+=b+= c`, and expects to be parsed into `a+=(b+=c)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::PlusEquals, loc 0, 1, 0, 3),
+            mktoken!(TokenKind::Identifier(String::from("b")), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::PlusEquals, loc 0, 4, 0, 6),
+            mktoken!(TokenKind::Identifier(String::from("c")), loc 0, 6, 0, 7),
+        ],
+        mkast!(prog loc 0, 0, 0, 7, vec![
+            mkast!(infix InfixPlusEquals, loc 0, 0, 0, 7,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixPlusEquals, loc 0, 3, 0, 7,
+                    left mkast!(identifier "b", loc 0, 3, 0, 4),
+                    right mkast!(identifier "c", loc 0, 6, 0, 7),
+                ),
+            ),
+        ])
+    )]
+    #[case::two_minus_equals(
+        // Represents `a-=b-=c`, and expects to be parsed into `a-=(b-=c)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::MinusEquals, loc 0, 1, 0, 3),
+            mktoken!(TokenKind::Identifier(String::from("b")), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::MinusEquals, loc 0, 4, 0, 6),
+            mktoken!(TokenKind::Identifier(String::from("c")), loc 0, 6, 0, 7),
+        ],
+        mkast!(prog loc 0, 0, 0, 7, vec![
+            mkast!(infix InfixMinusEquals, loc 0, 0, 0, 7,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixMinusEquals, loc 0, 3, 0, 7,
+                    left mkast!(identifier "b", loc 0, 3, 0, 4),
+                    right mkast!(identifier "c", loc 0, 6, 0, 7),
+                ),
+            ),
+        ])
+    )]
+    #[case::two_asterisk_equals(
+        // Represents `a*=b*=c`, and expects to be parsed into `a*=(b*=c)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::AsteriskEquals, loc 0, 1, 0, 3),
+            mktoken!(TokenKind::Identifier(String::from("b")), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::AsteriskEquals, loc 0, 4, 0, 6),
+            mktoken!(TokenKind::Identifier(String::from("c")), loc 0, 6, 0, 7),
+        ],
+        mkast!(prog loc 0, 0, 0, 7, vec![
+            mkast!(infix InfixAsteriskEquals, loc 0, 0, 0, 7,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixAsteriskEquals, loc 0, 3, 0, 7,
+                    left mkast!(identifier "b", loc 0, 3, 0, 4),
+                    right mkast!(identifier "c", loc 0, 6, 0, 7),
+                ),
+            ),
+        ])
+    )]
+    #[case::two_slash_equals(
+        // Represents `a/=b/=c`, and expects to be parsed into `a/=(b/=c)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::SlashEquals, loc 0, 1, 0, 3),
+            mktoken!(TokenKind::Identifier(String::from("b")), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::SlashEquals, loc 0, 4, 0, 6),
+            mktoken!(TokenKind::Identifier(String::from("c")), loc 0, 6, 0, 7),
+        ],
+        mkast!(prog loc 0, 0, 0, 7, vec![
+            mkast!(infix InfixSlashEquals, loc 0, 0, 0, 7,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixSlashEquals, loc 0, 3, 0, 7,
+                    left mkast!(identifier "b", loc 0, 3, 0, 4),
+                    right mkast!(identifier "c", loc 0, 6, 0, 7),
+                ),
+            ),
+        ])
+    )]
+    #[case::two_percent_equals(
+        // Represents `a%=b%=c`, and expects to be parsed into `a%=(b%=c)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::PercentEquals, loc 0, 1, 0, 3),
+            mktoken!(TokenKind::Identifier(String::from("b")), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::PercentEquals, loc 0, 4, 0, 6),
+            mktoken!(TokenKind::Identifier(String::from("c")), loc 0, 6, 0, 7),
+        ],
+        mkast!(prog loc 0, 0, 0, 7, vec![
+            mkast!(infix InfixPercentEquals, loc 0, 0, 0, 7,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixPercentEquals, loc 0, 3, 0, 7,
+                    left mkast!(identifier "b", loc 0, 3, 0, 4),
+                    right mkast!(identifier "c", loc 0, 6, 0, 7),
+                ),
+            ),
+        ])
+    )]
+    fn right_associativity(#[case] tokens: Vec<Token>, #[case] expected: Box<Ast>) {
+        assert_parse!(&tokens, expected);
+    }
+
+    #[rstest]
     #[case::asterisk_prioritized_over_plus(
         // Represents `1+2*3`, and expects to be parsed into `1+(2*3)`.
         vec![
@@ -822,6 +1137,25 @@ mod tests {
                 right mkast!(infix InfixPercent, loc 0, 2, 0, 5,
                     left mkast!(num 2.0, loc 0, 2, 0, 3),
                     right mkast!(num 3.0, loc 0, 4, 0, 5),
+                ),
+            ),
+        ])
+    )]
+    #[case::plus_prioritized_over_equals(
+        // Represents `a=1+2`, and expects to be parsed into `a=(1+2)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::Equals, loc 0, 1, 0, 2),
+            mktoken!(TokenKind::Number(1.0), loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Plus, loc 0, 3, 0, 4),
+            mktoken!(TokenKind::Number(2.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(infix InfixPlus, loc 0, 2, 0, 5,
+                    left mkast!(num 1.0, loc 0, 2, 0, 3),
+                    right mkast!(num 2.0, loc 0, 4, 0, 5),
                 ),
             ),
         ])
@@ -969,6 +1303,28 @@ mod tests {
         mkast!(prog loc 0, 0, 0, 3, vec![
             mkast!(num 1.0, loc 0, 0, 0, 1),
             mkast!(num 2.0, loc 0, 2, 0, 3),
+        ])
+    )]
+    #[case::two_bools(
+        // Represents `참 거짓`.
+        vec![
+            mktoken!(TokenKind::Bool(true), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::Bool(false), loc 0, 2, 0, 4),
+        ],
+        mkast!(prog loc 0, 0, 0, 4, vec![
+            mkast!(boolean true, loc 0, 0, 0, 1),
+            mkast!(boolean false, loc 0, 2, 0, 4),
+        ])
+    )]
+    #[case::two_identifiers(
+        // Represents `사과 오렌지`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::Identifier(String::from("오렌지")), loc 0, 3, 0, 6),
+        ],
+        mkast!(prog loc 0, 0, 0, 6, vec![
+            mkast!(identifier "사과", loc 0, 0, 0, 2),
+            mkast!(identifier "오렌지", loc 0, 3, 0, 6),
         ])
     )]
     fn multiple_tokens(#[case] tokens: Vec<Token>, #[case] expected: Box<Ast>) {

--- a/komi_parser/src/lib.rs
+++ b/komi_parser/src/lib.rs
@@ -137,6 +137,10 @@ impl<'a> Parser<'a> {
                 let get_kind = |left, right| AstKind::InfixDisjunct { left, right };
                 self.read_right_and_make_infix_ast(left, &bp::CONNECTIVE_BP, get_kind)
             }
+            TokenKind::Equals => {
+                let get_kind = |left, right| AstKind::InfixEquals { left, right };
+                self.read_right_and_make_infix_ast(left, &Bp::ASSIGNMENT, get_kind)
+            }
             _ => panic!("todo"), // NOTE: this undetermined cases came from calling of the parse_expression(), and bp says nothing about the token kinds explicitly
         }
     }
@@ -470,6 +474,20 @@ mod tests {
             mkast!(infix InfixDisjunct, loc 0, 0, 0, 7,
                 left mkast!(boolean true, loc 0, 0, 0, 1),
                 right mkast!(boolean false, loc 0, 5, 0, 7),
+            ),
+        ])
+    )]
+    #[case::equals(
+        // Represents `a = 1`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("a")), loc 0, 0, 0, 1),
+            mktoken!(TokenKind::Equals, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(infix InfixEquals, loc 0, 0, 0, 5,
+                left mkast!(identifier "a", loc 0, 0, 0, 1),
+                right mkast!(num 1.0, loc 0, 4, 0, 5),
             ),
         ])
     )]

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -19,6 +19,11 @@ pub enum AstKind {
     InfixConjunct { left: Box<Ast>, right: Box<Ast> },
     InfixDisjunct { left: Box<Ast>, right: Box<Ast> },
     InfixEquals { left: Box<Ast>, right: Box<Ast> },
+    InfixPlusEquals { left: Box<Ast>, right: Box<Ast> },
+    InfixMinusEquals { left: Box<Ast>, right: Box<Ast> },
+    InfixAsteriskEquals { left: Box<Ast>, right: Box<Ast> },
+    InfixSlashEquals { left: Box<Ast>, right: Box<Ast> },
+    InfixPercentEquals { left: Box<Ast>, right: Box<Ast> },
 }
 
 /// An abstract syntax tree, or AST produced during parsing.

--- a/komi_syntax/src/bp/mod.rs
+++ b/komi_syntax/src/bp/mod.rs
@@ -13,12 +13,26 @@ pub const MULTIPLICATIVE_BP: Bp = Bp { left: 0o40, right: 0o41 };
 pub const PREFIX_BP: Bp = Bp { left: 0o70, right: 0o71 };
 
 impl Bp {
-    pub fn get_from_token(token: &Token) -> &'static Bp {
+    // Note that a token will be parsed into a right associative infix if the `left` is greater than the `right`, and vice versa.
+    pub const LOWEST: Self = Self { left: 0o0, right: 0o1 };
+    pub const ASSIGNMENT: Self = Self { left: 0o11, right: 0o10 };
+    pub const CONNECTIVE: Self = Self { left: 0o20, right: 0o21 };
+    pub const ADDITIVE: Self = Self { left: 0o30, right: 0o31 };
+    pub const MULTIPLICATIVE: Self = Self { left: 0o40, right: 0o41 };
+    pub const PREFIX: Self = Self { left: 0o70, right: 0o71 };
+
+    pub fn get_from_token(token: &Token) -> &Self {
         match token.kind {
-            TokenKind::Plus | TokenKind::Minus => &ADDITIVE_BP,
-            TokenKind::Asterisk | TokenKind::Slash | TokenKind::Percent => &MULTIPLICATIVE_BP,
-            TokenKind::Conjunct | TokenKind::Disjunct => &CONNECTIVE_BP,
-            _ => &LOWEST_BP,
+            TokenKind::Plus | TokenKind::Minus => &Self::ADDITIVE,
+            TokenKind::Equals
+            | TokenKind::PlusEquals
+            | TokenKind::MinusEquals
+            | TokenKind::AsteriskEquals
+            | TokenKind::SlashEquals
+            | TokenKind::PercentEquals => &Self::ASSIGNMENT,
+            TokenKind::Asterisk | TokenKind::Slash | TokenKind::Percent => &Self::MULTIPLICATIVE,
+            TokenKind::Conjunct | TokenKind::Disjunct => &Self::CONNECTIVE,
+            _ => &Self::LOWEST,
         }
     }
 }

--- a/komi_util/src/scanner/mod.rs
+++ b/komi_util/src/scanner/mod.rs
@@ -4,7 +4,20 @@ use crate::Range;
 pub trait Scanner {
     type Item;
 
+    // Returns the item at the current location.
     fn read(&self) -> Self::Item;
+
+    // Advances past the current item.
     fn advance(&mut self) -> ();
+
+    // Returns the location of the current item.
     fn locate(&self) -> Range;
+
+    // Returns the item at the current location, and advances.
+    // Same as calling `read()` and `locate()`.
+    fn read_and_advance(&mut self) -> Self::Item {
+        let item = self.read();
+        self.advance();
+        item
+    }
 }


### PR DESCRIPTION
parse `=`, `+=`, `-=`, `*=`, `/=`, and `%=`.

(implemented) property of equals infixes:
- arithmetic infixes should have higher priority over equals, e.g., `a=1+2` is parsed into `a=(1+2)`
- should be right associative, e.g., `a=b=c` is parsed into `a=(b=c)`