### PR TITLE
evaluate closure

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -66,6 +66,7 @@ mod tests {
     #[case::number_with_decimal("12.25", "12.25")]
     #[case::bool_true("참", "참")]
     #[case::bool_false("거짓", "거짓")]
+    #[case::closure("함수 사과, 오렌지, 바나나 {}", "함수 사과, 오렌지, 바나나 { ... }")]
     fn single_literal(#[case] source: &str, #[case] expected: String) {
         assert_exec!(source, expected);
     }

--- a/komi_evaluator/src/ast_reducer/assignment_infix/assignment_infix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/assignment_infix/assignment_infix_reducer/mod.rs
@@ -6,7 +6,7 @@ use komi_util::Range;
 
 type ResVal = Result<Value, EvalError>;
 
-pub fn reduce_equals(left: &Ast, right: &Ast, location: &Range, env: &mut Environment) -> ResVal {
+pub fn reduce_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
     let AstKind::Identifier(id_name) = &left.kind else {
         return Err(EvalError::new(EvalErrorKind::InvalidAssignmentLeftValue, left.location));
     };
@@ -18,7 +18,12 @@ pub fn reduce_equals(left: &Ast, right: &Ast, location: &Range, env: &mut Enviro
     Ok(assign_val)
 }
 
-pub fn reduce_equals_with_right_value(left: &Ast, right: Value, location: &Range, env: &mut Environment) -> ResVal {
+pub fn reduce_equals_with_right_value(
+    left: &Box<Ast>,
+    right: Value,
+    location: &Range,
+    env: &mut Environment,
+) -> ResVal {
     let AstKind::Identifier(id_name) = &left.kind else {
         return Err(EvalError::new(EvalErrorKind::InvalidAssignmentLeftValue, left.location));
     };

--- a/komi_evaluator/src/ast_reducer/assignment_infix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/assignment_infix/mod.rs
@@ -14,41 +14,41 @@ use komi_util::Range;
 type ResVal = Result<Value, EvalError>;
 
 /// Reduces the operands `left` and `right` of an equals infix to a value.
-pub fn reduce_equals(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_equals(left, right, infix_location, env)
+pub fn reduce_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_equals(left, right, location, env)
 }
 
 /// Reduces the operands `left` and `right` of a plus-equals infix to a value.
-pub fn reduce_plus_equals(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    let comb_reduced = comb::reduce_plus(left, right, infix_location, env)?;
+pub fn reduce_plus_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    let comb_reduced = comb::reduce_plus(left, right, location, env)?;
 
-    reducer::reduce_equals_with_right_value(left, comb_reduced, infix_location, env)
+    reducer::reduce_equals_with_right_value(left, comb_reduced, location, env)
 }
 
 /// Reduces the operands `left` and `right` of a minus-equals infix to a value.
-pub fn reduce_minus_equals(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    let comb_reduced = comb::reduce_minus(left, right, infix_location, env)?;
+pub fn reduce_minus_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    let comb_reduced = comb::reduce_minus(left, right, location, env)?;
 
-    reducer::reduce_equals_with_right_value(left, comb_reduced, infix_location, env)
+    reducer::reduce_equals_with_right_value(left, comb_reduced, location, env)
 }
 
 /// Reduces the operands `left` and `right` of a asterisk-equals infix to a value.
-pub fn reduce_asterisk_equals(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    let comb_reduced = comb::reduce_asterisk(left, right, infix_location, env)?;
+pub fn reduce_asterisk_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    let comb_reduced = comb::reduce_asterisk(left, right, location, env)?;
 
-    reducer::reduce_equals_with_right_value(left, comb_reduced, infix_location, env)
+    reducer::reduce_equals_with_right_value(left, comb_reduced, location, env)
 }
 
 /// Reduces the operands `left` and `right` of a slash-equals infix to a value.
-pub fn reduce_slash_equals(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    let comb_reduced = comb::reduce_slash(left, right, infix_location, env)?;
+pub fn reduce_slash_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    let comb_reduced = comb::reduce_slash(left, right, location, env)?;
 
-    reducer::reduce_equals_with_right_value(left, comb_reduced, infix_location, env)
+    reducer::reduce_equals_with_right_value(left, comb_reduced, location, env)
 }
 
 /// Reduces the operands `left` and `right` of a percent-equals infix to a value.
-pub fn reduce_percent_equals(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    let comb_reduced = comb::reduce_percent(left, right, infix_location, env)?;
+pub fn reduce_percent_equals(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    let comb_reduced = comb::reduce_percent(left, right, location, env)?;
 
-    reducer::reduce_equals_with_right_value(left, comb_reduced, infix_location, env)
+    reducer::reduce_equals_with_right_value(left, comb_reduced, location, env)
 }

--- a/komi_evaluator/src/ast_reducer/combinator_infix/combinator_infix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/combinator_infix/combinator_infix_reducer/mod.rs
@@ -9,8 +9,8 @@ type ResVal = Result<Value, EvalError>;
 /// Reduces the operand `operand` of a numeric infix operand to a value.
 /// Its primitive value and kind are determined by `reduce_infix` and `get_kind`, respectively.
 pub fn reduce_num<F, G>(
-    left: &Ast,
-    right: &Ast,
+    left: &Box<Ast>,
+    right: &Box<Ast>,
     location: &Range,
     env: &mut Environment,
     reduce_infix: F,
@@ -26,8 +26,8 @@ where
 /// Reduces the operand `operand` of a boolean infix operand to a value.
 /// Its primitive value and kind are determined by `reduce_infix` and `get_kind`, respectively.
 pub fn reduce_bool<F, G>(
-    left: &Ast,
-    right: &Ast,
+    left: &Box<Ast>,
+    right: &Box<Ast>,
     location: &Range,
     env: &mut Environment,
     reduce_infix: F,
@@ -40,11 +40,11 @@ where
     reduce(left, right, location, env, get_bool_primitive, reduce_infix, get_kind)
 }
 
-fn get_num_primitive(ast: &Ast, env: &mut Environment) -> Result<f64, EvalError> {
+fn get_num_primitive(ast: &Box<Ast>, env: &mut Environment) -> Result<f64, EvalError> {
     util::get_num_primitive_or_error(ast, EvalErrorKind::InvalidNumInfixOperand, env)
 }
 
-fn get_bool_primitive(ast: &Ast, env: &mut Environment) -> Result<bool, EvalError> {
+fn get_bool_primitive(ast: &Box<Ast>, env: &mut Environment) -> Result<bool, EvalError> {
     util::get_bool_primitive_or_error(ast, EvalErrorKind::InvalidBoolInfixOperand, env)
 }
 
@@ -56,8 +56,8 @@ fn get_bool_primitive(ast: &Ast, env: &mut Environment) -> Result<bool, EvalErro
 ///
 /// The location is determined by `location`.
 fn reduce<T, F, G, H>(
-    left: &Ast,
-    right: &Ast,
+    left: &Box<Ast>,
+    right: &Box<Ast>,
     location: &Range,
     env: &mut Environment,
     reduce_operand: F,
@@ -65,7 +65,7 @@ fn reduce<T, F, G, H>(
     get_kind: H,
 ) -> ResVal
 where
-    F: Fn(&Ast, &mut Environment) -> Result<T, EvalError>,
+    F: Fn(&Box<Ast>, &mut Environment) -> Result<T, EvalError>,
     G: Fn(T, T) -> T,
     H: Fn(T) -> ValueKind,
 {

--- a/komi_evaluator/src/ast_reducer/combinator_infix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/combinator_infix/mod.rs
@@ -14,36 +14,36 @@ use komi_util::Range;
 type ResVal = Result<Value, EvalError>;
 
 /// Reduces the operands `left` and `right` of a plus infix to a value.
-pub fn reduce_plus(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_num(left, right, infix_location, env, |l, r| l + r, |v| ValueKind::Number(v))
+pub fn reduce_plus(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_num(left, right, location, env, |l, r| l + r, |v| ValueKind::Number(v))
 }
 
 /// Reduces the operands `left` and `right` of a minus infix to a value.
-pub fn reduce_minus(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_num(left, right, infix_location, env, |l, r| l - r, |v| ValueKind::Number(v))
+pub fn reduce_minus(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_num(left, right, location, env, |l, r| l - r, |v| ValueKind::Number(v))
 }
 
 /// Reduces the operands `left` and `right` of a asterisk infix to a value.
-pub fn reduce_asterisk(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_num(left, right, infix_location, env, |l, r| l * r, |v| ValueKind::Number(v))
+pub fn reduce_asterisk(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_num(left, right, location, env, |l, r| l * r, |v| ValueKind::Number(v))
 }
 
 /// Reduces the operands `left` and `right` of a slash infix to a value.
-pub fn reduce_slash(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_num(left, right, infix_location, env, |l, r| l / r, |v| ValueKind::Number(v))
+pub fn reduce_slash(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_num(left, right, location, env, |l, r| l / r, |v| ValueKind::Number(v))
 }
 
 /// Reduces the operands `left` and `right` of a percent infix to a value.
-pub fn reduce_percent(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_num(left, right, infix_location, env, |l, r| l % r, |v| ValueKind::Number(v))
+pub fn reduce_percent(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_num(left, right, location, env, |l, r| l % r, |v| ValueKind::Number(v))
 }
 
 /// Reduces the operands `left` and `right` of a conjunction infix to a value.
-pub fn reduce_conjunct(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_bool(left, right, infix_location, env, |l, r| l && r, |v| ValueKind::Bool(v))
+pub fn reduce_conjunct(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_bool(left, right, location, env, |l, r| l && r, |v| ValueKind::Bool(v))
 }
 
 /// Reduces the operands `left` and `right` of a disjunction infix to a value.
-pub fn reduce_disjunct(left: &Ast, right: &Ast, infix_location: &Range, env: &mut Environment) -> ResVal {
-    reducer::reduce_bool(left, right, infix_location, env, |l, r| l || r, |v| ValueKind::Bool(v))
+pub fn reduce_disjunct(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Environment) -> ResVal {
+    reducer::reduce_bool(left, right, location, env, |l, r| l || r, |v| ValueKind::Bool(v))
 }

--- a/komi_evaluator/src/ast_reducer/leaf/mod.rs
+++ b/komi_evaluator/src/ast_reducer/leaf/mod.rs
@@ -1,6 +1,6 @@
 use crate::environment::Environment;
 use crate::err::{EvalError, EvalErrorKind};
-use komi_syntax::{Value, ValueKind};
+use komi_syntax::{Ast, Value, ValueKind};
 use komi_util::Range;
 
 type ResVal = Result<Value, EvalError>;
@@ -26,6 +26,22 @@ pub fn evaluate_num(num: f64, location: &Range) -> ResVal {
 /// Returns the evaluated boolean result, from boolean `boolean` and its location `location`.
 pub fn evaluate_bool(boolean: bool, location: &Range) -> ResVal {
     Ok(Value::new(ValueKind::Bool(boolean), *location))
+}
+
+pub fn evaluate_closure(
+    parameters: &Vec<String>,
+    body: &Vec<Box<Ast>>,
+    location: &Range,
+    env: &mut Environment,
+) -> ResVal {
+    Ok(Value::new(
+        ValueKind::Closure {
+            parameters: parameters.clone(),
+            body: body.clone(),
+            env: env.clone(),
+        },
+        *location,
+    ))
 }
 
 #[cfg(test)]

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -7,6 +7,8 @@ mod util;
 
 use crate::environment::Environment;
 use crate::err::EvalError;
+use assignment_infix as assign_infix;
+use combinator_infix as comb_infix;
 use komi_syntax::{Ast, AstKind, Value};
 
 type ResVal = Result<Value, EvalError>;
@@ -26,21 +28,19 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Environment) -> ResVal {
         AstKind::PrefixPlus { operand: op } => prefix::reduce_plus(&op, &loc, env),
         AstKind::PrefixMinus { operand: op } => prefix::reduce_minus(&op, &loc, env),
         AstKind::PrefixBang { operand: op } => prefix::reduce_bang(&op, &loc, env),
-        AstKind::InfixPlus { left: l, right: r } => combinator_infix::reduce_plus(&l, &r, &loc, env),
-        AstKind::InfixMinus { left: l, right: r } => combinator_infix::reduce_minus(&l, &r, &loc, env),
-        AstKind::InfixAsterisk { left: l, right: r } => combinator_infix::reduce_asterisk(&l, &r, &loc, env),
-        AstKind::InfixSlash { left: l, right: r } => combinator_infix::reduce_slash(&l, &r, &loc, env),
-        AstKind::InfixPercent { left: l, right: r } => combinator_infix::reduce_percent(&l, &r, &loc, env),
-        AstKind::InfixConjunct { left: l, right: r } => combinator_infix::reduce_conjunct(&l, &r, &loc, env),
-        AstKind::InfixDisjunct { left: l, right: r } => combinator_infix::reduce_disjunct(&l, &r, &loc, env),
-        AstKind::InfixEquals { left: l, right: r } => assignment_infix::reduce_equals(&l, &r, &loc, env),
-        AstKind::InfixPlusEquals { left: l, right: r } => assignment_infix::reduce_plus_equals(&l, &r, &loc, env),
-        AstKind::InfixMinusEquals { left: l, right: r } => assignment_infix::reduce_minus_equals(&l, &r, &loc, env),
-        AstKind::InfixAsteriskEquals { left: l, right: r } => {
-            assignment_infix::reduce_asterisk_equals(&l, &r, &loc, env)
-        }
-        AstKind::InfixSlashEquals { left: l, right: r } => assignment_infix::reduce_slash_equals(&l, &r, &loc, env),
-        AstKind::InfixPercentEquals { left: l, right: r } => assignment_infix::reduce_percent_equals(&l, &r, &loc, env),
+        AstKind::InfixPlus { left: l, right: r } => comb_infix::reduce_plus(&l, &r, &loc, env),
+        AstKind::InfixMinus { left: l, right: r } => comb_infix::reduce_minus(&l, &r, &loc, env),
+        AstKind::InfixAsterisk { left: l, right: r } => comb_infix::reduce_asterisk(&l, &r, &loc, env),
+        AstKind::InfixSlash { left: l, right: r } => comb_infix::reduce_slash(&l, &r, &loc, env),
+        AstKind::InfixPercent { left: l, right: r } => comb_infix::reduce_percent(&l, &r, &loc, env),
+        AstKind::InfixConjunct { left: l, right: r } => comb_infix::reduce_conjunct(&l, &r, &loc, env),
+        AstKind::InfixDisjunct { left: l, right: r } => comb_infix::reduce_disjunct(&l, &r, &loc, env),
+        AstKind::InfixEquals { left: l, right: r } => assign_infix::reduce_equals(&l, &r, &loc, env),
+        AstKind::InfixPlusEquals { left: l, right: r } => assign_infix::reduce_plus_equals(&l, &r, &loc, env),
+        AstKind::InfixMinusEquals { left: l, right: r } => assign_infix::reduce_minus_equals(&l, &r, &loc, env),
+        AstKind::InfixAsteriskEquals { left: l, right: r } => assign_infix::reduce_asterisk_equals(&l, &r, &loc, env),
+        AstKind::InfixSlashEquals { left: l, right: r } => assign_infix::reduce_slash_equals(&l, &r, &loc, env),
+        AstKind::InfixPercentEquals { left: l, right: r } => assign_infix::reduce_percent_equals(&l, &r, &loc, env),
         _ => todo!(),
     }
 }

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -11,7 +11,7 @@ use komi_syntax::{Ast, AstKind, Value};
 
 type ResVal = Result<Value, EvalError>;
 
-pub fn reduce_ast(ast: &Ast, env: &mut Environment) -> ResVal {
+pub fn reduce_ast(ast: &Box<Ast>, env: &mut Environment) -> ResVal {
     // Design principle: once you read something, pass it as an argument.
     // This avoids unnecessary repeated reading in subfunctions.
     // Moreover, if you delay determining the kind of what you read, the decision is only postponed to subfunctions.

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -22,9 +22,9 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Environment) -> ResVal {
     let loc = ast.location;
     match &ast.kind {
         AstKind::Program { expressions: e } => expressions::reduce(&e, &loc, env),
-        AstKind::Identifier(x) => leaf::evaluate_identifier(x, &loc, env),
-        AstKind::Number(x) => leaf::evaluate_num(*x, &loc),
-        AstKind::Bool(x) => leaf::evaluate_bool(*x, &loc),
+        AstKind::Identifier(id) => leaf::evaluate_identifier(id, &loc, env),
+        AstKind::Number(n) => leaf::evaluate_num(*n, &loc),
+        AstKind::Bool(b) => leaf::evaluate_bool(*b, &loc),
         AstKind::PrefixPlus { operand: op } => prefix::reduce_plus(&op, &loc, env),
         AstKind::PrefixMinus { operand: op } => prefix::reduce_minus(&op, &loc, env),
         AstKind::PrefixBang { operand: op } => prefix::reduce_bang(&op, &loc, env),

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -25,6 +25,7 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Environment) -> ResVal {
         AstKind::Identifier(id) => leaf::evaluate_identifier(id, &loc, env),
         AstKind::Number(n) => leaf::evaluate_num(*n, &loc),
         AstKind::Bool(b) => leaf::evaluate_bool(*b, &loc),
+        AstKind::Closure { parameters: p, body: b } => leaf::evaluate_closure(p, b, &loc, env),
         AstKind::PrefixPlus { operand: op } => prefix::reduce_plus(&op, &loc, env),
         AstKind::PrefixMinus { operand: op } => prefix::reduce_minus(&op, &loc, env),
         AstKind::PrefixBang { operand: op } => prefix::reduce_bang(&op, &loc, env),
@@ -41,7 +42,6 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Environment) -> ResVal {
         AstKind::InfixAsteriskEquals { left: l, right: r } => assign_infix::reduce_asterisk_equals(&l, &r, &loc, env),
         AstKind::InfixSlashEquals { left: l, right: r } => assign_infix::reduce_slash_equals(&l, &r, &loc, env),
         AstKind::InfixPercentEquals { left: l, right: r } => assign_infix::reduce_percent_equals(&l, &r, &loc, env),
-        _ => todo!(),
     }
 }
 
@@ -103,27 +103,8 @@ mod tests {
         );
     }
 
-    mod single_ast {
+    mod identifier {
         use super::*;
-
-        #[rstest]
-        #[case::num(
-            // Represents `1`.
-            mkast!(prog loc 0, 0, 0, 1, vec![
-                mkast!(num 1.0, loc 0, 0, 0, 1),
-            ]),
-            Value::from_num(1.0, Range::from_nums(0, 0, 0, 1))
-        )]
-        #[case::bool(
-            // Represents `참`.
-            mkast!(prog loc 0, 0, 0, 1, vec![
-                mkast!(boolean true, loc 0, 0, 0, 1),
-            ]),
-            Value::from_bool(true, Range::from_nums(0, 0, 0, 1))
-        )]
-        fn single_literal(#[case] ast: Box<Ast>, #[case] expected: Value) {
-            assert_eval!(&ast, expected);
-        }
 
         #[rstest]
         #[case::num(
@@ -158,6 +139,51 @@ mod tests {
         )]
         fn single_undefined_identifier(#[case] ast: Box<Ast>, #[case] error: EvalError) {
             assert_eval_fail!(&ast, error);
+        }
+    }
+
+    mod leaf {
+        use super::*;
+
+        #[rstest]
+        #[case::num(
+            // Represents `1`.
+            mkast!(prog loc 0, 0, 0, 1, vec![
+                mkast!(num 1.0, loc 0, 0, 0, 1),
+            ]),
+            Value::from_num(1.0, Range::from_nums(0, 0, 0, 1))
+        )]
+        #[case::bool(
+            // Represents `참`.
+            mkast!(prog loc 0, 0, 0, 1, vec![
+                mkast!(boolean true, loc 0, 0, 0, 1),
+            ]),
+            Value::from_bool(true, Range::from_nums(0, 0, 0, 1))
+        )]
+        #[case::closure(
+            // Represents `함수 사과, 오렌지, 바나나 { 1 2 3 }`.
+            mkast!(prog loc 0, 0, 0, 25, vec![
+                mkast!(closure loc 0, 0, 0, 25,
+                    param vec![String::from("사과"), String::from("오렌지"), String::from("바나나")],
+                    body vec![
+                        mkast!(num 1.0, loc 0, 18, 0, 19),
+                        mkast!(num 2.0, loc 0, 20, 0, 21),
+                        mkast!(num 3.0, loc 0, 22, 0, 23),
+                    ],
+                ),
+            ]),
+            Value::new(ValueKind::Closure {
+                parameters: vec![String::from("사과"), String::from("오렌지"), String::from("바나나")],
+                body: vec![
+                    mkast!(num 1.0, loc 0, 18, 0, 19),
+                    mkast!(num 2.0, loc 0, 20, 0, 21),
+                    mkast!(num 3.0, loc 0, 22, 0, 23),
+                ],
+                env: Environment::new()
+            }, Range::from_nums(0, 0, 0, 25))
+        )]
+        fn single(#[case] ast: Box<Ast>, #[case] expected: Value) {
+            assert_eval!(&ast, expected);
         }
     }
 

--- a/komi_evaluator/src/ast_reducer/prefix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/prefix/mod.rs
@@ -8,16 +8,16 @@ use komi_util::Range;
 type ResVal = Result<Value, EvalError>;
 
 /// Reduces the operand `operand` of a plus prefix to a value, with its location spanning from the prefix to the operand.
-pub fn reduce_plus(operand: &Ast, prefix_location: &Range, env: &mut Environment) -> ResVal {
+pub fn reduce_plus(operand: &Box<Ast>, prefix_location: &Range, env: &mut Environment) -> ResVal {
     prefix_reducer::reduce_num(operand, prefix_location, env, |v| ValueKind::Number(v))
 }
 
 /// Reduces the operand `operand` of a plus prefix to a value, with its location spanning from the prefix to the operand.
-pub fn reduce_minus(operand: &Ast, prefix_location: &Range, env: &mut Environment) -> ResVal {
+pub fn reduce_minus(operand: &Box<Ast>, prefix_location: &Range, env: &mut Environment) -> ResVal {
     prefix_reducer::reduce_num(operand, prefix_location, env, |v| ValueKind::Number(-v))
 }
 
 /// Reduces the operand `operand` of a plus prefix to a value, with its location spanning from the prefix to the operand.
-pub fn reduce_bang(operand: &Ast, prefix_location: &Range, env: &mut Environment) -> ResVal {
+pub fn reduce_bang(operand: &Box<Ast>, prefix_location: &Range, env: &mut Environment) -> ResVal {
     prefix_reducer::reduce_bool(operand, prefix_location, env, |v| ValueKind::Bool(!v))
 }

--- a/komi_evaluator/src/ast_reducer/prefix/prefix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/prefix/prefix_reducer/mod.rs
@@ -7,7 +7,7 @@ use komi_util::Range;
 type ResVal = Result<Value, EvalError>;
 
 /// Reduces the operand `operand` of a numeric prefix operand to a value, with its kind determined by `get_kind`.
-pub fn reduce_num<F>(operand: &Ast, prefix_location: &Range, env: &mut Environment, get_kind: F) -> ResVal
+pub fn reduce_num<F>(operand: &Box<Ast>, prefix_location: &Range, env: &mut Environment, get_kind: F) -> ResVal
 where
     F: Fn(f64) -> ValueKind,
 {
@@ -15,18 +15,18 @@ where
 }
 
 /// Reduces the operand `operand` of a boolean prefix operand to a value, with its kind determined by `get_kind`.
-pub fn reduce_bool<F>(operand: &Ast, prefix_location: &Range, env: &mut Environment, get_kind: F) -> ResVal
+pub fn reduce_bool<F>(operand: &Box<Ast>, prefix_location: &Range, env: &mut Environment, get_kind: F) -> ResVal
 where
     F: Fn(bool) -> ValueKind,
 {
     reduce(operand, prefix_location, env, get_bool_primitive, get_kind)
 }
 
-fn get_num_primitive(ast: &Ast, env: &mut Environment) -> Result<f64, EvalError> {
+fn get_num_primitive(ast: &Box<Ast>, env: &mut Environment) -> Result<f64, EvalError> {
     util::get_num_primitive_or_error(ast, EvalErrorKind::InvalidNumPrefixOperand, env)
 }
 
-fn get_bool_primitive(ast: &Ast, env: &mut Environment) -> Result<bool, EvalError> {
+fn get_bool_primitive(ast: &Box<Ast>, env: &mut Environment) -> Result<bool, EvalError> {
     util::get_bool_primitive_or_error(ast, EvalErrorKind::InvalidBoolPrefixOperand, env)
 }
 
@@ -37,14 +37,14 @@ fn get_bool_primitive(ast: &Ast, env: &mut Environment) -> Result<bool, EvalErro
 ///
 /// The location in the returned value will span from the prefix to operand.
 fn reduce<T, F, G>(
-    operand: &Ast,
+    operand: &Box<Ast>,
     prefix_location: &Range,
     env: &mut Environment,
     reduce_operand: F,
     get_kind: G,
 ) -> ResVal
 where
-    F: Fn(&Ast, &mut Environment) -> Result<T, EvalError>,
+    F: Fn(&Box<Ast>, &mut Environment) -> Result<T, EvalError>,
     G: Fn(T) -> ValueKind,
 {
     let reduced = reduce_operand(operand, env)?;

--- a/komi_evaluator/src/ast_reducer/util/mod.rs
+++ b/komi_evaluator/src/ast_reducer/util/mod.rs
@@ -6,7 +6,7 @@ use komi_syntax::{Ast, ValueKind};
 /// Reduces the AST `ast` to an evaluated result, and map it with `op`.
 ///
 /// `op` should return `EvalErrorKind` on erroneous case, which then automatically converted into `EvalError` in the returned result.
-pub fn reduce_and_map_kind<T, F>(ast: &Ast, env: &mut Environment, op: F) -> Result<T, EvalError>
+pub fn reduce_and_map_kind<T, F>(ast: &Box<Ast>, env: &mut Environment, op: F) -> Result<T, EvalError>
 where
     F: Fn(&ValueKind) -> Result<T, EvalErrorKind>,
 {
@@ -19,7 +19,7 @@ where
 }
 
 pub fn get_num_primitive_or_error(
-    ast: &Ast,
+    ast: &Box<Ast>,
     error_kind: EvalErrorKind,
     env: &mut Environment,
 ) -> Result<f64, EvalError> {
@@ -30,7 +30,7 @@ pub fn get_num_primitive_or_error(
 }
 
 pub fn get_bool_primitive_or_error(
-    ast: &Ast,
+    ast: &Box<Ast>,
     error_kind: EvalErrorKind,
     env: &mut Environment,
 ) -> Result<bool, EvalError> {

--- a/komi_evaluator/src/environment/mod.rs
+++ b/komi_evaluator/src/environment/mod.rs
@@ -1,37 +1,7 @@
 use komi_syntax::Value;
-use std::collections::HashMap;
+use komi_util;
 
-pub struct Environment {
-    outer: Option<Box<Environment>>,
-    table: HashMap<String, Value>,
-}
-
-impl Environment {
-    pub fn new() -> Self {
-        Self { outer: None, table: HashMap::new() }
-    }
-
-    pub fn from_outer(outer: Environment) -> Self {
-        Self { outer: Some(Box::new(outer)), table: HashMap::new() }
-    }
-
-    pub fn get(&self, name: &str) -> Option<&Value> {
-        // Return the value if found.
-        if let Some(value) = self.table.get(name) {
-            return Some(value);
-        }
-
-        // Since not found in the current environment, try in the outer environment.
-        match &self.outer {
-            Some(x) => x.get(name),
-            None => None,
-        }
-    }
-
-    pub fn set(&mut self, name: &str, value: &Value) -> () {
-        self.table.insert(name.to_string(), value.clone());
-    }
-}
+pub type Environment = komi_util::Environment<Value>;
 
 #[cfg(test)]
 mod tests {

--- a/komi_evaluator/src/environment/mod.rs
+++ b/komi_evaluator/src/environment/mod.rs
@@ -36,18 +36,23 @@ impl Environment {
 #[cfg(test)]
 mod tests {
     use super::Environment;
+    use fixtures::*;
     use komi_syntax::{Value, ValueKind};
     use komi_util::Range;
     use rstest::rstest;
 
-    const VALUE_MOCK: Value = Value::new(ValueKind::Number(1.0), Range::from_nums(0, 0, 0, 1));
+    mod fixtures {
+        use super::*;
+
+        pub const VALUE_MOCK: &Value = &Value::new(ValueKind::Number(1.0), Range::from_nums(0, 0, 0, 1));
+    }
 
     #[rstest]
     #[case::set_and_get_some(
         // Represents `foo = 1.0`.
         vec![("foo", VALUE_MOCK)],
         "foo",
-        Some(&VALUE_MOCK),
+        Some(VALUE_MOCK),
     )]
     #[case::set_and_get_none(
         // Represents no binding.
@@ -55,7 +60,7 @@ mod tests {
         "foo",
         None
     )]
-    fn single_environment(#[case] to_set: Vec<(&str, Value)>, #[case] to_get: &str, #[case] expected: Option<&Value>) {
+    fn single_environment(#[case] to_set: Vec<(&str, &Value)>, #[case] to_get: &str, #[case] expected: Option<&Value>) {
         let mut env = Environment::new();
         for (k, v) in to_set {
             env.set(k, &v);
@@ -71,7 +76,7 @@ mod tests {
         // Represents `foo = 1.0`.
         vec![("foo", VALUE_MOCK)],
         "foo",
-        Some(&VALUE_MOCK),
+        Some(VALUE_MOCK),
     )]
     #[case::set_and_get_none(
         // Represents no binding.
@@ -79,7 +84,7 @@ mod tests {
         "foo",
         None
     )]
-    fn outer_environment(#[case] to_set: Vec<(&str, Value)>, #[case] to_get: &str, #[case] expected: Option<&Value>) {
+    fn outer_environment(#[case] to_set: Vec<(&str, &Value)>, #[case] to_get: &str, #[case] expected: Option<&Value>) {
         let mut outer_env = Environment::new();
         for (k, v) in to_set {
             outer_env.set(k, &v);

--- a/komi_evaluator/src/lib.rs
+++ b/komi_evaluator/src/lib.rs
@@ -17,11 +17,11 @@ type ResVal = Result<Value, EvalError>;
 
 /// Produces a value from an AST.
 struct Evaluator<'a> {
-    ast: &'a Ast,
+    ast: &'a Box<Ast>,
 }
 
 impl<'a> Evaluator<'a> {
-    pub fn new(ast: &'a Ast) -> Self {
+    pub fn new(ast: &'a Box<Ast>) -> Self {
         Self { ast }
     }
 
@@ -33,6 +33,6 @@ impl<'a> Evaluator<'a> {
 }
 
 /// Produces a value from an AST.
-pub fn eval(ast: &Ast) -> ResVal {
+pub fn eval(ast: &Box<Ast>) -> ResVal {
     Evaluator::new(ast).eval()
 }

--- a/komi_representer/src/lib.rs
+++ b/komi_representer/src/lib.rs
@@ -42,7 +42,7 @@ fn represent_closure(parameters: &Vec<String>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use komi_util::Range;
+    use komi_util::{Environment, Range};
 
     const RANGE_MOCKS: &[Range] = &[Range::from_nums(0, 0, 0, 1), Range::from_nums(0, 1, 0, 2)];
 
@@ -93,6 +93,7 @@ mod tests {
                     ValueKind::Closure {
                         parameters: vec![String::from("사과"), String::from("오렌지"), String::from("바나나")],
                         body: vec![],
+                        env: Environment::<Value>::new(),
                     },
                     RANGE_MOCKS[0]
                 ),

--- a/komi_representer/src/lib.rs
+++ b/komi_representer/src/lib.rs
@@ -8,12 +8,15 @@ use komi_syntax::{Value, ValueKind};
 pub const EMPTY_REPR: &str = "(EMPTY)";
 pub const TRUE_REPR: &str = "참";
 pub const FALSE_REPR: &str = "거짓";
+pub const CLOSURE_REPR_KEYWORD: &str = "함수";
+pub const CLOSURE_REPR_BODY: &str = "{ ... }";
 
 /// Produces the string representation for a given value.
 pub fn represent(val: &Value) -> String {
-    match val.kind {
+    match &val.kind {
         ValueKind::Number(n) => n.to_string(),
-        ValueKind::Bool(b) => represent_bool(b),
+        ValueKind::Bool(b) => represent_bool(*b),
+        ValueKind::Closure { parameters: p, .. } => represent_closure(p),
         ValueKind::Empty => EMPTY_REPR.to_string(),
     }
 }
@@ -23,6 +26,16 @@ fn represent_bool(boolean: bool) -> String {
         true => TRUE_REPR.to_string(),
         false => FALSE_REPR.to_string(),
     }
+}
+
+fn represent_closure(parameters: &Vec<String>) -> String {
+    let mut parts: Vec<String> = vec![];
+    parts.push(String::from(CLOSURE_REPR_KEYWORD));
+    parts.push(parameters.join(", "));
+    parts.push(String::from(CLOSURE_REPR_BODY));
+
+    let repr = parts.join(" ");
+    repr
 }
 
 /// Note: Use the constant `EMPTY_REPR` to test the representation of the empty value, to avoid depending on the implementation detail.
@@ -70,6 +83,21 @@ mod tests {
         #[test]
         fn test_false_bool() {
             assert_repr!(&Value::new(ValueKind::Bool(false), RANGE_MOCKS[0]), "거짓");
+        }
+
+        /// Represents `함수 사과, 오렌지, 바나나 {}`.
+        #[test]
+        fn test_closure() {
+            assert_repr!(
+                &Value::new(
+                    ValueKind::Closure {
+                        parameters: vec![String::from("사과"), String::from("오렌지"), String::from("바나나")],
+                        body: vec![],
+                    },
+                    RANGE_MOCKS[0]
+                ),
+                "함수 사과, 오렌지, 바나나 { ... }"
+            );
         }
     }
 

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -1,5 +1,5 @@
 use crate::Ast;
-use komi_util::Range;
+use komi_util::{Environment, Range};
 
 /// Kinds of values produced during evaluation.
 /// Serves as the interface between an evaluator and its user.
@@ -7,7 +7,11 @@ use komi_util::Range;
 pub enum ValueKind {
     Number(f64),
     Bool(bool),
-    Closure { parameters: Vec<String>, body: Vec<Box<Ast>> },
+    Closure {
+        parameters: Vec<String>,
+        body: Vec<Box<Ast>>,
+        env: Environment<Value>,
+    },
     Empty,
 }
 

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -1,3 +1,4 @@
+use crate::Ast;
 use komi_util::Range;
 
 /// Kinds of values produced during evaluation.
@@ -6,6 +7,7 @@ use komi_util::Range;
 pub enum ValueKind {
     Number(f64),
     Bool(bool),
+    Closure { parameters: Vec<String>, body: Vec<Box<Ast>> },
     Empty,
 }
 

--- a/komi_util/src/environment/mod.rs
+++ b/komi_util/src/environment/mod.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+pub struct Environment<T> {
+    outer: Option<Box<Environment<T>>>,
+    table: HashMap<String, T>,
+}
+
+impl<T: Clone> Environment<T> {
+    pub fn new() -> Self {
+        Self { outer: None, table: HashMap::new() }
+    }
+
+    pub fn from_outer(outer: Environment<T>) -> Self {
+        Self { outer: Some(Box::new(outer)), table: HashMap::new() }
+    }
+
+    pub fn get(&self, name: &str) -> Option<&T> {
+        // Return the value if found.
+        if let Some(value) = self.table.get(name) {
+            return Some(value);
+        }
+
+        // Since not found in the current environment, try in the outer environment.
+        match &self.outer {
+            Some(x) => x.get(name),
+            None => None,
+        }
+    }
+
+    pub fn set(&mut self, name: &str, value: &T) -> () {
+        self.table.insert(name.to_string(), value.clone());
+    }
+}
+
+// For unit tests, see the `Environment` in the `komi_evaluator` crate.

--- a/komi_util/src/environment/mod.rs
+++ b/komi_util/src/environment/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[derive(Debug, PartialEq, Clone)]
 pub struct Environment<T> {
     outer: Option<Box<Environment<T>>>,
     table: HashMap<String, T>,

--- a/komi_util/src/lib.rs
+++ b/komi_util/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod char_validator;
+pub mod environment;
 pub mod error;
 pub mod location;
 pub mod scanner;
 pub mod tape;
 pub mod unpacker;
 
+pub use environment::Environment;
 pub use error::EngineError;
 pub use location::range;
 pub use location::range::Range;

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -90,6 +90,16 @@ mod tests {
     mod ok {
         use super::*;
 
+        mod closure {
+            use super::*;
+
+            test_exec!(
+                closure,
+                "함수 사과, 오렌지, 바나나 {}",
+                "함수 사과, 오렌지, 바나나 { ... }"
+            );
+        }
+
         mod num {
             use super::*;
 


### PR DESCRIPTION
add closure to the value system, its representation, and evaluating logic.

note:
- capturing scope: environment is "freezed" and deeply copied into a closure value when evaluated. it prevents from capturing any variables declared below the closure, since the environment can't "see" the variables.
- body is deeply copied: closure evaluations happen while the entire ast tree is reduced. the ast tree is partially deeply copied to store the body.