### PR TITLE
parse calls

### DIFF
--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -42,6 +42,7 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Environment) -> ResVal {
         AstKind::InfixAsteriskEquals { left: l, right: r } => assign_infix::reduce_asterisk_equals(&l, &r, &loc, env),
         AstKind::InfixSlashEquals { left: l, right: r } => assign_infix::reduce_slash_equals(&l, &r, &loc, env),
         AstKind::InfixPercentEquals { left: l, right: r } => assign_infix::reduce_percent_equals(&l, &r, &loc, env),
+        _ => todo!(),
     }
 }
 

--- a/komi_parser/src/err/mod.rs
+++ b/komi_parser/src/err/mod.rs
@@ -17,9 +17,12 @@ pub enum ParseErrorKind {
     InvalidFuncParam,
     // A function body beginning with `{` is not closed, such as `함수 {`
     FuncBodyNotClosed,
+    // Invalid tokens in call arguments, such as `사과(`.
+    InvalidCallArgs,
     /// An internal error impossible to occur if parsed as expected.
     Unexpected,
 }
+// TODO: rename func to closure
 
 pub type ParseError = EngineError<ParseErrorKind>;
 
@@ -32,6 +35,7 @@ impl fmt::Display for ParseErrorKind {
             ParseErrorKind::NoPrefixOperand => "NoPrefixOperand",
             ParseErrorKind::InvalidFuncParam => "InvalidFuncParam",
             ParseErrorKind::FuncBodyNotClosed => "FuncBodyNotClosed",
+            ParseErrorKind::InvalidCallArgs => "InvalidCallArgs",
             ParseErrorKind::Unexpected => "Unexpected",
         };
         write!(f, "{}", s)

--- a/komi_parser/src/lib.rs
+++ b/komi_parser/src/lib.rs
@@ -176,6 +176,7 @@ impl<'a> Parser<'a> {
             TokenKind::AsteriskEquals => read_right_and_make_infix_ast!(self, left, ASSIGNMENT, InfixAsteriskEquals),
             TokenKind::SlashEquals => read_right_and_make_infix_ast!(self, left, ASSIGNMENT, InfixSlashEquals),
             TokenKind::PercentEquals => read_right_and_make_infix_ast!(self, left, ASSIGNMENT, InfixPercentEquals),
+            TokenKind::LParen => self.read_right_and_make_call_ast(left),
             _ => panic!("todo"), // NOTE: this undetermined cases came from calling of the parse_expression(), and bp says nothing about the token kinds explicitly
         }
     }
@@ -216,6 +217,59 @@ impl<'a> Parser<'a> {
         let kind = get_kind(operand);
         let prefix = Box::new(Ast::new(kind, location));
         Ok(prefix)
+    }
+
+    fn read_right_and_make_call_ast(&mut self, left: Box<Ast>) -> ResAst {
+        // Return an error if end
+        let Some(token) = self.scanner.read_and_advance() else {
+            let location = Range::new(left.location.begin, self.scanner.locate().end);
+            return Err(ParseError::new(ParseErrorKind::InvalidCallArgs, location));
+        };
+
+        let arguments = self.read_call_arguments(token)?;
+
+        let location = Range::new(left.location.begin, self.scanner.locate().begin);
+        let kind = AstKind::Call { target: left, arguments };
+        let call = Box::new(Ast::new(kind, location));
+
+        Ok(call)
+    }
+
+    fn read_call_arguments(&mut self, first_token: &'a Token) -> Result<Vec<Box<Ast>>, ParseError> {
+        // This function will read the pattern `first_arg [, arg]*`
+
+        let mut arguments: Vec<Box<Ast>> = vec![];
+
+        if first_token.kind == TokenKind::RParen {
+            return Ok(arguments);
+        }
+
+        let first_arg = self.parse_expression(first_token, &Bp::LOWEST)?;
+        arguments.push(first_arg);
+
+        while let Some(token) = self.scanner.read_and_advance() {
+            // Successfully break if end of arguments
+            if token.kind == TokenKind::RParen {
+                break;
+            }
+
+            // Return error if invalid syntax due to a missing comma
+            if token.kind != TokenKind::Comma {
+                // TODO: return more specific error like `NoCommaCallArgs`
+                return Err(ParseError::new(ParseErrorKind::InvalidCallArgs, token.location));
+            }
+
+            // Return error if end of source while reading arguments
+            let next_token_location = self.scanner.locate();
+            let Some(next_token) = self.scanner.read_and_advance() else {
+                return Err(ParseError::new(ParseErrorKind::InvalidCallArgs, next_token_location));
+            };
+
+            let arg = self.parse_expression(next_token, &Bp::LOWEST)?;
+            arguments.push(arg);
+        }
+
+        Ok(arguments)
     }
 
     fn read_right_and_make_infix_ast<F>(&mut self, left: Box<Ast>, bp: &Bp, get_kind: F) -> ResAst
@@ -1381,6 +1435,7 @@ mod tests {
         assert_parse_fail!(&tokens, error);
     }
 
+    // TODO: test ending with parameter, comma and double comma in parameter list without body
     #[rstest]
     #[case::no_parameters_and_empty_body(
         // Represents `함수 {}`.
@@ -1532,6 +1587,98 @@ mod tests {
         ParseError::new(ParseErrorKind::FuncBodyNotClosed, Range::from_nums(0, 6, 0, 6))
     )]
     fn invalid_closure(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
+        assert_parse_fail!(&tokens, error);
+    }
+
+    #[rstest]
+    #[case::id_with_no_args(
+        // Represents `사과()`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::LParen, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::RParen, loc 0, 3, 0, 4),
+        ],
+        mkast!(prog loc 0, 0, 0, 4, vec![
+            mkast!(call loc 0, 0, 0, 4,
+                target mkast!(identifier "사과", loc 0, 0, 0, 2),
+                args vec![],
+            ),
+        ])
+    )]
+    #[case::id_with_single_arg(
+        // Represents `사과(1)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::LParen, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::RParen, loc 0, 4, 0, 5),
+        ],
+        mkast!(prog loc 0, 0, 0, 5, vec![
+            mkast!(call loc 0, 0, 0, 5,
+                target mkast!(identifier "사과", loc 0, 0, 0, 2),
+                args vec![
+                    mkast!(num 1.0, loc 0, 3, 0, 4),
+                ],
+            ),
+        ])
+    )]
+    #[case::id_with_multiple_args(
+        // Represents `사과(1,2,3)`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::LParen, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::Comma, loc 0, 4, 0, 5),
+            mktoken!(TokenKind::Number(2.0), loc 0, 5, 0, 6),
+            mktoken!(TokenKind::Comma, loc 0, 6, 0, 7),
+            mktoken!(TokenKind::Number(3.0), loc 0, 7, 0, 8),
+            mktoken!(TokenKind::RParen, loc 0, 8, 0, 9),
+        ],
+        mkast!(prog loc 0, 0, 0, 9, vec![
+            mkast!(call loc 0, 0, 0, 9,
+                target mkast!(identifier "사과", loc 0, 0, 0, 2),
+                args vec![
+                    mkast!(num 1.0, loc 0, 3, 0, 4),
+                    mkast!(num 2.0, loc 0, 5, 0, 6),
+                    mkast!(num 3.0, loc 0, 7, 0, 8),
+                ],
+            ),
+        ])
+    )]
+    fn call(#[case] tokens: Vec<Token>, #[case] expected: Box<Ast>) {
+        assert_parse!(&tokens, expected);
+    }
+
+    #[rstest]
+    #[case::end_with_lparen(
+        // Represents `사과(`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::LParen, loc 0, 2, 0, 3),
+        ],
+        ParseError::new(ParseErrorKind::InvalidCallArgs, Range::from_nums(0, 0, 0, 3))
+    )]
+    #[case::comma_after_lparen(
+        // Represents `사과(,`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::LParen, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Comma, loc 0, 3, 0, 4),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 3, 0, 4))
+    )]
+    #[case::two_comma_after_arg(
+        // Represents `사과(1,,`.
+        vec![
+            mktoken!(TokenKind::Identifier(String::from("사과")), loc 0, 0, 0, 2),
+            mktoken!(TokenKind::LParen, loc 0, 2, 0, 3),
+            mktoken!(TokenKind::Number(1.0), loc 0, 3, 0, 4),
+            mktoken!(TokenKind::Comma, loc 0, 4, 0, 5),
+            mktoken!(TokenKind::Comma, loc 0, 5, 0, 6),
+        ],
+        ParseError::new(ParseErrorKind::InvalidExprStart, Range::from_nums(0, 5, 0, 6))
+    )]
+    fn invalid_call(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
         assert_parse_fail!(&tokens, error);
     }
 

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -25,6 +25,7 @@ pub enum AstKind {
     InfixSlashEquals { left: Box<Ast>, right: Box<Ast> },
     InfixPercentEquals { left: Box<Ast>, right: Box<Ast> },
     Closure { parameters: Vec<String>, body: Vec<Box<Ast>> },
+    Call { target: Box<Ast>, arguments: Vec<Box<Ast>> },
 }
 
 /// An abstract syntax tree, or AST produced during parsing.
@@ -68,9 +69,16 @@ macro_rules! mkast {
             Range::from_nums($br, $bc, $er, $ec),
         ))
     };
+    // TODO: fix param to params
     (closure loc $br:expr, $bc:expr, $er:expr, $ec: expr, param $param:expr, body $body:expr $(,)?) => {
         Box::new(Ast::new(
             AstKind::Closure { parameters: $param, body: $body },
+            Range::from_nums($br, $bc, $er, $ec),
+        ))
+    };
+    (call loc $br:expr, $bc:expr, $er:expr, $ec: expr, target $target:expr, args $args:expr $(,)?) => {
+        Box::new(Ast::new(
+            AstKind::Call { target: $target, arguments: $args },
             Range::from_nums($br, $bc, $er, $ec),
         ))
     };

--- a/komi_syntax/src/bp/mod.rs
+++ b/komi_syntax/src/bp/mod.rs
@@ -6,12 +6,6 @@ pub struct Bp {
     pub right: u8,
 }
 
-pub const LOWEST_BP: Bp = Bp { left: 0o0, right: 0o1 };
-pub const CONNECTIVE_BP: Bp = Bp { left: 0o20, right: 0o21 };
-pub const ADDITIVE_BP: Bp = Bp { left: 0o30, right: 0o31 };
-pub const MULTIPLICATIVE_BP: Bp = Bp { left: 0o40, right: 0o41 };
-pub const PREFIX_BP: Bp = Bp { left: 0o70, right: 0o71 };
-
 impl Bp {
     // Note that a token will be parsed into a right associative infix if the `left` is greater than the `right`, and vice versa.
     pub const LOWEST: Self = Self { left: 0o0, right: 0o1 };

--- a/komi_syntax/src/bp/mod.rs
+++ b/komi_syntax/src/bp/mod.rs
@@ -13,7 +13,8 @@ impl Bp {
     pub const CONNECTIVE: Self = Self { left: 0o20, right: 0o21 };
     pub const ADDITIVE: Self = Self { left: 0o30, right: 0o31 };
     pub const MULTIPLICATIVE: Self = Self { left: 0o40, right: 0o41 };
-    pub const PREFIX: Self = Self { left: 0o70, right: 0o71 };
+    pub const PREFIX: Self = Self { left: 0o60, right: 0o61 };
+    pub const CALL: Self = Self { left: 0o70, right: 0o71 };
 
     pub fn get_from_token(token: &Token) -> &Self {
         match token.kind {
@@ -26,6 +27,7 @@ impl Bp {
             | TokenKind::PercentEquals => &Self::ASSIGNMENT,
             TokenKind::Asterisk | TokenKind::Slash | TokenKind::Percent => &Self::MULTIPLICATIVE,
             TokenKind::Conjunct | TokenKind::Disjunct => &Self::CONNECTIVE,
+            TokenKind::LParen => &Self::CALL,
             _ => &Self::LOWEST,
         }
     }


### PR DESCRIPTION
tried a more type-safe ast architecture, but decided to stick with this version and made some progress.

the issue is when to validate the call target (where the call target refers to `foo` in `foo()`, for example):
- in this ast architecture, the "type" cannot be determined at parsing time. that is, the parser doesn't care about what comes in the call target position. so it's the evaluator's responsibility to validate whether the call target is actually "callable".