### PR TITLE
support string and interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "komi_wasm"
-version = "0.1.0-beta7"
+version = "0.1.0-beta8"
 dependencies = [
  "const_format",
  "js-sys",

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -88,6 +88,7 @@ mod tests {
     #[case::number_with_decimal("12.25", "12.25")]
     #[case::bool_true("참", "참")]
     #[case::bool_false("거짓", "거짓")]
+    #[case::str_without_interploation("\"사과 오렌지\"", "사과 오렌지")]
     #[case::closure("함수 사과, 오렌지, 바나나 { 1 }", "함수 사과, 오렌지, 바나나 { ... }")]
     fn single_literal(#[case] source: &str, #[case] expected: String) {
         assert_out!(source, expected, "");
@@ -336,6 +337,14 @@ mod tests {
     fn assignment_with_wrong_type(#[case] source: &str, #[case] error: ExecError) {
         assert_fail!(source, error);
     }
+
+    #[rstest]
+    #[case::curring_call("사과 = 42 오렌지 = 참 \"{사과}{오렌지}\"", "42참")]
+    fn string_interpolation(#[case] source: &str, #[case] expected: String) {
+        assert_out!(source, expected, "");
+    }
+
+    // TODO: test closure captures
 
     #[rstest]
     #[case::immediate_closure_call("함수{1}()", "1")]

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -54,6 +54,7 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> ValRes
             assign_infix::reduce_percent_equals(&l, &r, &loc, env, stdouts)
         }
         AstKind::Call { target: t, arguments: args } => call::evaluate(t, args, &loc, env, stdouts),
+        _ => todo!(),
     }
 }
 

--- a/komi_lexer/src/lexer_tool/str/mod.rs
+++ b/komi_lexer/src/lexer_tool/str/mod.rs
@@ -18,7 +18,8 @@ pub fn lex_str(scanner: &mut SourceScanner, first_location: Range) -> TokenRes {
         // Return error if end of source
         let first_char_location = scanner.locate();
         let Some(first_char) = scanner.read_and_advance() else {
-            return Err(LexError::new(LexErrorKind::NoClosingQuoteInStr, seg_location));
+            let str_location = Range::new(first_location.begin, first_char_location.end);
+            return Err(LexError::new(LexErrorKind::NoClosingQuoteInStr, str_location));
         };
 
         // Break if end of string literal

--- a/komi_lexer/src/lib.rs
+++ b/komi_lexer/src/lib.rs
@@ -408,6 +408,10 @@ mod tests {
 
     // Should fail to lex illegal str literals.
     #[rstest]
+    #[case::no_closing_quote(
+        "\"사과",
+        mkerr!(NoClosingQuoteInStr, str_loc!("", "\"사과")))
+    ]
     #[case::lbrace_not_closed_with_immediate_end(
         "\"{",
         mkerr!(NoClosingBraceInInterpolation, str_loc!("\"", "{")))

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -113,6 +113,9 @@ macro_rules! mkast {
     (boolean $val:expr, loc $range:expr) => {
         Box::new(Ast::new(AstKind::Bool($val), $range))
     };
+    (string loc $range:expr, $val:expr $(,)?) => {
+        Box::new(Ast::new(AstKind::Str($val), $range))
+    };
 }
 
 #[cfg(test)]

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -1,4 +1,5 @@
 use komi_util::Range;
+pub use komi_util::{StrSegment, StrSegmentKind};
 
 /// Kinds of AST produced during parsing.
 /// Serves as the interface between a parser and its user.
@@ -7,6 +8,7 @@ pub enum AstKind {
     Program { expressions: Vec<Box<Ast>> },
     Number(f64),
     Bool(bool),
+    Str(Vec<StrSegment>),
     Identifier(String),
     PrefixPlus { operand: Box<Ast> },
     PrefixMinus { operand: Box<Ast> },

--- a/komi_syntax/src/token/mod.rs
+++ b/komi_syntax/src/token/mod.rs
@@ -1,4 +1,5 @@
 use komi_util::Range;
+pub use komi_util::{StrSegment, StrSegmentKind};
 
 /// A token produced during lexing.
 #[derive(Debug, PartialEq, Clone)]
@@ -85,38 +86,6 @@ pub enum TokenKind {
     ElseBranch,
     /// An iteration keyword `반복`.
     Iteration,
-}
-
-/// A string segment in a string token.
-#[derive(Debug, PartialEq, Clone)]
-pub struct StrSegment {
-    pub kind: StrSegmentKind,
-    pub location: Range,
-}
-
-impl StrSegment {
-    pub fn new(kind: StrSegmentKind, location: Range) -> Self {
-        Self { kind, location }
-    }
-}
-
-/// A kind of string segment in a string token.
-#[derive(Debug, PartialEq, Clone)]
-pub enum StrSegmentKind {
-    /// A string segment, such as `사과` in "`사과{오렌지}`".
-    Str(String),
-    /// An interpolated identifier, such as `오렌지` in "`사과{오렌지}`".
-    Identifier(String),
-}
-
-impl StrSegmentKind {
-    pub fn str(s: impl Into<String>) -> Self {
-        Self::Str(s.into())
-    }
-
-    pub fn identifier(s: impl Into<String>) -> Self {
-        Self::Identifier(s.into())
-    }
 }
 
 /// Makes a token with the kind and the location.

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -10,6 +10,7 @@ use representation::Representer;
 pub enum ValueKind {
     Number(f64),
     Bool(bool),
+    Str(String),
     Closure {
         parameters: Vec<String>,
         body: Vec<Box<Ast>>,

--- a/komi_syntax/src/value/representation/mod.rs
+++ b/komi_syntax/src/value/representation/mod.rs
@@ -14,6 +14,7 @@ impl Representer {
         match &val.kind {
             ValueKind::Number(n) => Self::represent_number(*n),
             ValueKind::Bool(b) => Self::represent_bool(*b),
+            ValueKind::Str(s) => Self::represent_str(s),
             ValueKind::Closure { parameters: p, .. } => Self::represent_closure(p),
             ValueKind::BuiltinFunc(_) => Self::represent_builtin_func(),
         }
@@ -28,6 +29,10 @@ impl Representer {
             true => Self::TRUE.to_string(),
             false => Self::FALSE.to_string(),
         }
+    }
+
+    fn represent_str(string: &String) -> String {
+        string.clone()
     }
 
     fn represent_closure(parameters: &Vec<String>) -> String {

--- a/komi_util/src/environment/mod.rs
+++ b/komi_util/src/environment/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+/// A lexical environment implemented as a linked list of hash maps.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Environment<T> {
     outer: Option<Box<Environment<T>>>,

--- a/komi_util/src/lib.rs
+++ b/komi_util/src/lib.rs
@@ -3,6 +3,7 @@ pub mod environment;
 pub mod error;
 pub mod location;
 pub mod scanner;
+pub mod str_segment;
 pub mod tape;
 pub mod unpacker;
 
@@ -12,4 +13,5 @@ pub use location::range;
 pub use location::range::Range;
 pub use location::spot::Spot;
 pub use scanner::Scanner;
+pub use str_segment::{StrSegment, StrSegmentKind};
 pub use tape::Tape;

--- a/komi_util/src/location/mod.rs
+++ b/komi_util/src/location/mod.rs
@@ -1,2 +1,4 @@
+//! A location in multi-line text.
+
 pub mod range;
 pub mod spot;

--- a/komi_util/src/location/spot/mod.rs
+++ b/komi_util/src/location/spot/mod.rs
@@ -1,3 +1,5 @@
+//! A single coordinate.
+
 /// A position representing the coordinate of a character in multi-line text.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Spot {

--- a/komi_util/src/scanner/mod.rs
+++ b/komi_util/src/scanner/mod.rs
@@ -1,6 +1,6 @@
 use crate::Range;
 
-/// Reading units one by one with spanning the location.
+/// Represents a structure that reads units one by one with spanning the location.
 pub trait Scanner {
     type Item;
 

--- a/komi_util/src/str_segment/mod.rs
+++ b/komi_util/src/str_segment/mod.rs
@@ -39,3 +39,10 @@ impl StrSegmentKind {
         Self::Identifier(s.into())
     }
 }
+
+#[macro_export]
+macro_rules! mkstrseg {
+    ($kind:ident, $val:expr, $range:expr) => {
+        StrSegment::new(StrSegmentKind::$kind($val.to_owned()), $range)
+    };
+}

--- a/komi_util/src/str_segment/mod.rs
+++ b/komi_util/src/str_segment/mod.rs
@@ -1,0 +1,36 @@
+//! StrSegment
+//! A segment of a string.
+
+use crate::Range;
+
+/// A string segment in a string token.
+#[derive(Debug, PartialEq, Clone)]
+pub struct StrSegment {
+    pub kind: StrSegmentKind,
+    pub location: Range,
+}
+
+impl StrSegment {
+    pub fn new(kind: StrSegmentKind, location: Range) -> Self {
+        Self { kind, location }
+    }
+}
+
+/// A kind of string segment in a string token.
+#[derive(Debug, PartialEq, Clone)]
+pub enum StrSegmentKind {
+    /// A string segment, such as `사과` in "`사과{오렌지}`".
+    Str(String),
+    /// An interpolated identifier, such as `오렌지` in "`사과{오렌지}`".
+    Identifier(String),
+}
+
+impl StrSegmentKind {
+    pub fn str(s: impl Into<String>) -> Self {
+        Self::Str(s.into())
+    }
+
+    pub fn identifier(s: impl Into<String>) -> Self {
+        Self::Identifier(s.into())
+    }
+}

--- a/komi_util/src/str_segment/mod.rs
+++ b/komi_util/src/str_segment/mod.rs
@@ -1,5 +1,10 @@
-//! StrSegment
-//! A segment of a string.
+//! A segment of a string for syntax modules.
+//!
+//! A module to express string interpolations.
+//! See [`token`] and [`ast`] modules.
+//!
+//! [`token`]: ../../komi_syntax/token/struct.StrSegment.html
+//! [`ast`]: ../../komi_syntax/ast/struct.StrSegment.html
 
 use crate::Range;
 
@@ -19,9 +24,9 @@ impl StrSegment {
 /// A kind of string segment in a string token.
 #[derive(Debug, PartialEq, Clone)]
 pub enum StrSegmentKind {
-    /// A string segment, such as `사과` in "`사과{오렌지}`".
+    /// A string segment, such as `사과` in `"사과{오렌지}"`.
     Str(String),
-    /// An interpolated identifier, such as `오렌지` in "`사과{오렌지}`".
+    /// An interpolated identifier, such as `오렌지` in `"사과{오렌지}"`.
     Identifier(String),
 }
 

--- a/komi_util/src/tape/mod.rs
+++ b/komi_util/src/tape/mod.rs
@@ -1,4 +1,4 @@
-/// A tape-like behaviour that reads items one by one, with the ability to peek at the next item without advancing.
+/// Represents a structure that reads items one by one, with the ability to peek at the next item without advancing.
 pub trait Tape {
     type Item;
 

--- a/komi_wasm/Cargo.toml
+++ b/komi_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "komi_wasm"
-version = "0.1.0-beta7"
+version = "0.1.0-beta8"
 edition = "2024"
 
 [dependencies]

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -128,6 +128,7 @@ mod tests {
             test_exec!(num, "12.25", "12.25", "");
             test_exec!(the_true, "참", "참", "");
             test_exec!(the_false, "거짓", "거짓", "");
+            test_exec!(string_without_interpolation, "\"사과\"", "사과", "");
         }
 
         mod prefixes {
@@ -191,6 +192,13 @@ mod tests {
             test_exec!(modular_assignment, "사과=6 사과%=4 사과", "2", "");
 
             test_error!(mixed_type, "사과=참 사과+=1", "EvalError", "NonNumInfixOperand", loc str_loc!("사과=참 ", "사과"));
+
+            test_exec!(
+                string_with_interpolation,
+                "사과=42 오렌지=참 \"{사과}{오렌지}바나나\"",
+                "42참바나나",
+                ""
+            );
         }
 
         mod call {
@@ -219,6 +227,10 @@ mod tests {
             test_error!(only_comment, "# comment", "LexError", "NoSource", loc str_loc!("", "# comment"));
             test_error!(illegal_char, "^", "LexError", "IllegalChar", loc str_loc!("", "^")); // `^` represents an illegal char.
             test_error!(arithmetic_plus, "12.", "LexError", "IllegalNumLiteral", loc str_loc!("", "12."));
+            test_error!(no_closing_quote_str, "\"사과 오렌지", "LexError", "NoClosingQuoteInStr", loc str_loc!("", "\"사과 오렌지"));
+            test_error!(no_closing_brace_str, "\"{사과}{오렌지", "LexError", "NoClosingBraceInInterpolation", loc str_loc!("\"{사과}", "{오렌지"));
+            test_error!(empty_interpolation, "\"{사과}{}", "LexError", "NoIdentifierInInterpolation", loc str_loc!("\"{사과}", "{}"));
+            test_error!(illegal_interpolation, "\"{사+", "LexError", "IllegalInterpolationChar", loc str_loc!("\"{사", "+"));
         }
 
         mod parse {


### PR DESCRIPTION
supported syntax: `"str"`, `"{id}"`, or using them together like `"str1{id1}str2{id2}"` in arbitrary order