### PR TITLE
infer types on build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "komi_wasm"
-version = "0.1.0-beta8"
+version = "0.1.0-beta9"
 dependencies = [
  "const_format",
  "js-sys",

--- a/komi_wasm/Cargo.toml
+++ b/komi_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "komi_wasm"
-version = "0.1.0-beta8"
+version = "0.1.0-beta9"
 edition = "2024"
 
 [dependencies]

--- a/komi_wasm/src/lib.rs
+++ b/komi_wasm/src/lib.rs
@@ -1,11 +1,12 @@
 pub mod util;
 
-use util::res_converter::convert;
+use util::res_converter::JsConverter;
 use wasm_bindgen::prelude::*;
 
 pub type JsRes = Result<JsValue, JsValue>;
 
 #[wasm_bindgen]
 pub fn execute(source: &str) -> JsRes {
-    convert(&komi::execute(source))
+    let exec_out = komi::execute(source);
+    JsConverter::convert(exec_out)
 }

--- a/komi_wasm/src/util/res_converter/js_structs/mod.rs
+++ b/komi_wasm/src/util/res_converter/js_structs/mod.rs
@@ -1,0 +1,44 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(getter_with_clone, js_name = "ExecOut")]
+pub struct JsExecOut {
+    #[wasm_bindgen(readonly)]
+    pub value: String,
+    #[wasm_bindgen(readonly)]
+    pub stdout: String,
+}
+
+#[wasm_bindgen(getter_with_clone, js_name = "ExecError")]
+pub struct JsExecError {
+    #[wasm_bindgen(readonly)]
+    pub name: String,
+    #[wasm_bindgen(readonly)]
+    pub message: String,
+    #[wasm_bindgen(readonly)]
+    pub cause: JsExecErrorCause,
+}
+
+#[wasm_bindgen(getter_with_clone, js_name = "ExecErrorCause")]
+#[derive(Clone)]
+pub struct JsExecErrorCause {
+    #[wasm_bindgen(getter_with_clone, readonly)]
+    pub location: JsRange,
+}
+
+#[wasm_bindgen(getter_with_clone, js_name = "Range")]
+#[derive(Clone)]
+pub struct JsRange {
+    #[wasm_bindgen(getter_with_clone, readonly)]
+    pub begin: JsSpot,
+    #[wasm_bindgen(getter_with_clone, readonly)]
+    pub end: JsSpot,
+}
+
+#[wasm_bindgen(getter_with_clone, js_name = "Spot")]
+#[derive(Clone)]
+pub struct JsSpot {
+    #[wasm_bindgen(readonly)]
+    pub row: u32,
+    #[wasm_bindgen(readonly)]
+    pub col: u32,
+}

--- a/komi_wasm/tests/res_converter/mod.rs
+++ b/komi_wasm/tests/res_converter/mod.rs
@@ -4,26 +4,19 @@ mod tests {
     use js_sys::{Error, Number};
     use komi::ExecOut;
     use komi_wasm::util::js_val::obj;
-    use komi_wasm::util::res_converter::convert;
+    use komi_wasm::util::res_converter::JsConverter;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::*;
 
     /// The converted result is expected to be a JavaScript value (`JsValue`), which is a JavaScript object.
-    /// The interface will be as below, in TypeScript syntax:
-    ///
-    /// ```ts
-    /// {
-    ///   value: string;
-    ///   stdout: string;
-    /// }
-    /// ```
+    /// For the specific interface, refer to `build/komi.d.ts` file in this crate.
     #[wasm_bindgen_test]
     fn test_convert_ok() -> Result<(), JsValue> {
         // Suppose the execution returns Ok
         let exec_out = Ok(ExecOut::new(value(), stdout()));
 
         // The converted result is expected to be a JavaScript value (`JsValue`)
-        let converted = convert(&exec_out)?;
+        let converted = JsConverter::convert(exec_out)?;
 
         // `converted` should have `value` field
         let converted_value = obj::get_property(&converted, "value")?;
@@ -39,35 +32,12 @@ mod tests {
     }
 
     /// The converted error is expected to be a JavaScript value (`JsValue`), which is a JavaScript `Error` object.
-    /// The interface of the `Error` will be as below, in TypeScript syntax:
-    ///
-    /// ```ts
-    /// {
-    ///   name: string;
-    ///   message: string;
-    ///   cause: {
-    ///     location: {
-    ///       begin: {
-    ///         col: number;
-    ///         row: number;
-    ///       },
-    ///       end: {
-    ///         col: number;
-    ///         row: number;
-    ///       },
-    ///     };
-    ///   };
-    /// }
-    /// ```
-    ///
-    /// For the details of JavaScript `Error`, see [MDN documentation].
-    ///
-    /// [MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    /// For the specific interface, refer to `build/komi.d.ts` file in this crate.
     #[wasm_bindgen_test]
     fn test_convert_err() -> Result<(), JsValue> {
         let exec_out = Err(exec_err());
 
-        let converted = convert(&exec_out);
+        let converted = JsConverter::convert(exec_out);
 
         // `converted` should have `cause` field (according to the JavaScript Error class)
         let converted_cause = Error::from(converted.unwrap_err()).cause();

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -39,7 +39,6 @@ macro_rules! assert_exec {
         let res = execute($src)?;
         let repr = get_property(&res, "value")?;
         let stdout = get_property(&res, "stdout")?;
-        dbg!(res);
 
         assert_eq!(
             JsString::from(repr),

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -7,10 +7,10 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
 macro_rules! test_exec {
-    ($name:ident, $src:expr, $expected_repr:expr, $expected_stdout:expr $(,)?) => {
+    ($name:ident, $src:expr, $expected_value:expr, $expected_stdout:expr $(,)?) => {
         #[wasm_bindgen_test]
         fn $name() -> Result<(), JsValue> {
-            assert_exec!($src, $expected_repr, $expected_stdout);
+            assert_exec!($src, $expected_value, $expected_stdout);
             Ok(())
         }
     };
@@ -35,14 +35,14 @@ macro_rules! test_error {
 }
 
 macro_rules! assert_exec {
-    ($src:expr, $expected_repr:expr, $expected_stdout:expr) => {
+    ($src:expr, $expected_value:expr, $expected_stdout:expr) => {
         let res = execute($src)?;
         let repr = get_property(&res, "value")?;
         let stdout = get_property(&res, "stdout")?;
 
         assert_eq!(
             JsString::from(repr),
-            JsString::from($expected_repr),
+            JsString::from($expected_value),
             "expected the value (left), but it isn't (right)"
         );
         assert_eq!(


### PR DESCRIPTION
replace manual `Object` creating with `wasm_bindgen` attributes to automatically generate correct type decalaration `d.ts` file in build artifact

users of this package then can import with correct types. previously the return value of `execute()` function was `any`.