### PR TITLE
fix return value type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "komi_wasm"
-version = "0.1.0-beta9"
+version = "0.1.0-beta10"
 dependencies = [
  "const_format",
  "js-sys",

--- a/komi_wasm/Cargo.toml
+++ b/komi_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "komi_wasm"
-version = "0.1.0-beta9"
+version = "0.1.0-beta10"
 edition = "2024"
 
 [dependencies]

--- a/komi_wasm/src/lib.rs
+++ b/komi_wasm/src/lib.rs
@@ -1,12 +1,12 @@
 pub mod util;
 
 use util::res_converter::JsConverter;
+pub use util::res_converter::{JsExecError, JsExecOut};
 use wasm_bindgen::prelude::*;
 
-pub type JsRes = Result<JsValue, JsValue>;
-
+/// Returns an object {@link ExecOut} if execution succeeds; throws an error {@link ExecError} if it fails.
 #[wasm_bindgen]
-pub fn execute(source: &str) -> JsRes {
+pub fn execute(source: &str) -> Result<JsExecOut, JsExecError> {
     let exec_out = komi::execute(source);
     JsConverter::convert(exec_out)
 }

--- a/komi_wasm/src/util/js_val/mod.rs
+++ b/komi_wasm/src/util/js_val/mod.rs
@@ -1,6 +1,5 @@
 pub mod obj;
 
-use crate::JsRes;
 use js_sys::{Error, Object};
 use komi_util::unpacker::unpack_spot;
 use komi_util::{Range, Spot};
@@ -30,7 +29,7 @@ pub fn convert_range_to_js_object(location: &Range) -> Result<Object, JsValue> {
 
 /// Converts an execution result to a JavaScript object with two fields `value` and `stdout`.
 /// These fields will be the string values from `repr` and `stdout`, respectively.
-pub fn convert_repr_and_stdout_to_js_val(repr: &str, stdout: &str) -> JsRes {
+pub fn convert_repr_and_stdout_to_js_val(repr: &str, stdout: &str) -> Result<JsValue, JsValue> {
     let obj = Object::new();
     obj::set_string_property(&obj, "value", repr)?;
     obj::set_string_property(&obj, "stdout", stdout)?;
@@ -38,7 +37,11 @@ pub fn convert_repr_and_stdout_to_js_val(repr: &str, stdout: &str) -> JsRes {
     Ok(obj.into())
 }
 
-pub fn convert_str_and_location_to_js_val(name: &str, message: &str, cause_location: &Range) -> JsRes {
+pub fn convert_str_and_location_to_js_val(
+    name: &str,
+    message: &str,
+    cause_location: &Range,
+) -> Result<JsValue, JsValue> {
     let cause = Object::new();
     let js_range_obj = convert_range_to_js_object(cause_location)?;
     obj::set_object_property(&cause, "location", &js_range_obj)?;

--- a/komi_wasm/src/util/res_converter/js_structs/mod.rs
+++ b/komi_wasm/src/util/res_converter/js_structs/mod.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen(getter_with_clone, js_name = "ExecOut")]
+#[derive(Debug)]
 pub struct JsExecOut {
     #[wasm_bindgen(readonly)]
     pub value: String,
@@ -9,6 +10,7 @@ pub struct JsExecOut {
 }
 
 #[wasm_bindgen(getter_with_clone, js_name = "ExecError")]
+#[derive(Debug)]
 pub struct JsExecError {
     #[wasm_bindgen(readonly)]
     pub name: String,
@@ -19,14 +21,14 @@ pub struct JsExecError {
 }
 
 #[wasm_bindgen(getter_with_clone, js_name = "ExecErrorCause")]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct JsExecErrorCause {
     #[wasm_bindgen(getter_with_clone, readonly)]
     pub location: JsRange,
 }
 
 #[wasm_bindgen(getter_with_clone, js_name = "Range")]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct JsRange {
     #[wasm_bindgen(getter_with_clone, readonly)]
     pub begin: JsSpot,
@@ -35,7 +37,7 @@ pub struct JsRange {
 }
 
 #[wasm_bindgen(getter_with_clone, js_name = "Spot")]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct JsSpot {
     #[wasm_bindgen(readonly)]
     pub row: u32,

--- a/komi_wasm/src/util/res_converter/mod.rs
+++ b/komi_wasm/src/util/res_converter/mod.rs
@@ -1,6 +1,5 @@
 mod js_structs;
 
-use crate::JsRes;
 pub use js_structs::{JsExecError, JsExecOut};
 use js_structs::{JsExecErrorCause, JsRange, JsSpot};
 use komi::{ExecError, ExecOut, ExecRes};
@@ -17,10 +16,10 @@ macro_rules! unpack_err {
 pub struct JsConverter {}
 
 impl JsConverter {
-    pub fn convert(exec_res: ExecRes) -> JsRes {
+    pub fn convert(exec_res: ExecRes) -> Result<JsExecOut, JsExecError> {
         match exec_res {
-            Ok(exec_out) => Ok(Self::convert_exec_out(exec_out).into()),
-            Err(exec_error) => Err(Self::convert_exec_error(exec_error).into()),
+            Ok(exec_out) => Ok(Self::convert_exec_out(exec_out)),
+            Err(exec_error) => Err(Self::convert_exec_error(exec_error)),
         }
     }
 

--- a/komi_wasm/tests/res_converter/mod.rs
+++ b/komi_wasm/tests/res_converter/mod.rs
@@ -16,7 +16,7 @@ mod tests {
         let exec_out = Ok(ExecOut::new(value(), stdout()));
 
         // The converted result is expected to be a JavaScript value (`JsValue`)
-        let converted = JsConverter::convert(exec_out)?;
+        let converted: JsValue = JsConverter::convert(exec_out)?.into();
 
         // `converted` should have `value` field
         let converted_value = obj::get_property(&converted, "value")?;
@@ -35,12 +35,13 @@ mod tests {
     /// For the specific interface, refer to `build/komi.d.ts` file in this crate.
     #[wasm_bindgen_test]
     fn test_convert_err() -> Result<(), JsValue> {
-        let exec_out = Err(exec_err());
+        let exec_res = Err(exec_err());
 
-        let converted = JsConverter::convert(exec_out);
+        let converted_res: JsValue = JsConverter::convert(exec_res).unwrap_err().into();
+        let converted_err: Error = converted_res.into();
 
         // `converted` should have `cause` field (according to the JavaScript Error class)
-        let converted_cause = Error::from(converted.unwrap_err()).cause();
+        let converted_cause = converted_err.cause();
 
         // The `cause` field should have `location` field
         let converted_location = obj::get_property(&converted_cause, "location")?;


### PR DESCRIPTION
correct the automatically generated `d.ts` file on build, from `execute(): any` to `execute(): ExecOut`.

the documentation for `execute()` function in rust is also converted to tsdoc in build artifact.