### PR TITLE
move exec error to syntax layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "const_format",
  "js-sys",
  "komi",
+ "komi_syntax",
  "komi_util",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -1,10 +1,7 @@
-mod err;
-
-// TODO: move errors to syntax module, since errors are interface among engines.
-pub use err::{EvalError, EvalErrorKind, ExecError, LexError, LexErrorKind, ParseError, ParseErrorKind};
 use komi_evaluator::Evaluator;
 use komi_lexer::lex;
 use komi_parser::parse;
+use komi_syntax::error::ExecError;
 
 pub type ExecRes = Result<ExecOut, ExecError>;
 
@@ -36,7 +33,7 @@ pub fn execute(source: &str) -> ExecRes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use komi_syntax::error::{EvalError, EvalErrorKind};
+    use komi_syntax::error::{EvalError, EvalErrorKind, LexError, LexErrorKind, ParseError, ParseErrorKind};
     use komi_util::location::Range;
     use rstest::rstest;
 

--- a/komi_syntax/src/error/exec/mod.rs
+++ b/komi_syntax/src/error/exec/mod.rs
@@ -1,4 +1,4 @@
-pub use komi_syntax::error::{EvalError, EvalErrorKind, LexError, LexErrorKind, ParseError, ParseErrorKind};
+use crate::error::{EvalError, LexError, ParseError};
 use std::error::Error;
 use std::fmt;
 

--- a/komi_syntax/src/error/mod.rs
+++ b/komi_syntax/src/error/mod.rs
@@ -1,7 +1,9 @@
 pub mod eval;
+pub mod exec;
 pub mod lex;
 pub mod parse;
 
 pub use eval::{EvalError, EvalErrorKind};
+pub use exec::ExecError;
 pub use lex::{LexError, LexErrorKind};
 pub use parse::{ParseError, ParseErrorKind};

--- a/komi_wasm/Cargo.toml
+++ b/komi_wasm/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 wasm-bindgen = "0.2.100"
 const_format = "0.2.34"
 komi = { path = "../komi" }
+komi_syntax = { path = "../komi_syntax" }
 komi_util = { path = "../komi_util" }
 js-sys = "0.3.77"
 

--- a/komi_wasm/src/util/res_converter/mod.rs
+++ b/komi_wasm/src/util/res_converter/mod.rs
@@ -2,7 +2,8 @@ mod js_structs;
 
 pub use js_structs::{JsExecError, JsExecOut};
 use js_structs::{JsExecErrorCause, JsRange, JsSpot};
-use komi::{ExecError, ExecOut, ExecRes};
+use komi::{ExecOut, ExecRes};
+use komi_syntax::error::ExecError;
 use komi_util::location::Range;
 use komi_util::unpacker::unpack_engine_error;
 

--- a/komi_wasm/tests/res_converter/mod.rs
+++ b/komi_wasm/tests/res_converter/mod.rs
@@ -65,7 +65,7 @@ mod tests {
     }
 
     mod fixtures {
-        use komi::{ExecError, LexError, LexErrorKind};
+        use komi_syntax::error::{ExecError, LexError, LexErrorKind};
         use komi_util::location::Range;
 
         pub fn value() -> String {


### PR DESCRIPTION
exec error is also an interface between komi (rust) and wasm