### PR TITLE
correct stdout write output for hangul

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -360,6 +360,8 @@ mod tests {
     #[rstest]
     #[case::num_without_decimal("쓰기(1)", "1", "1")]
     #[case::num_without_decimal("쓰기(12.25)", "5", "12.25")]
+    #[case::str_ascii("쓰기(\"foo\")", "3", "foo")]
+    #[case::str_hangul("쓰기(\"사과\")", "2", "사과")]
     fn stdout(#[case] source: &str, #[case] expected_repr: String, #[case] expected_stdout: String) {
         assert_out!(source, expected_repr, expected_stdout);
     }

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -9,7 +9,7 @@ pub fn bind(env: &mut Env) -> () {
 fn stdout_write(args: &Vec<Value>, stdouts: &mut Stdout) -> Value {
     let strs: Vec<String> = args.iter().map(|arg| arg.represent()).collect();
     let joined = strs.join(" ");
-    let joined_len = joined.len();
+    let joined_len = joined.chars().count();
 
     stdouts.push(joined);
 


### PR DESCRIPTION
for example, `쓰기("안녕")` returns value `2`, not `6` (the number of bytes)