### PR TITLE
parse branch

### DIFF
--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -56,6 +56,7 @@ pub fn reduce_ast(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> ValRes
             assign_infix::reduce_percent_equals(&l, &r, &loc, env, stdouts)
         }
         AstKind::Call { target: t, arguments: args } => call::evaluate(t, args, &loc, env, stdouts),
+        _ => todo!(),
     }
 }
 

--- a/komi_parser/src/lib.rs
+++ b/komi_parser/src/lib.rs
@@ -124,11 +124,16 @@ impl<'a> Parser<'a> {
         self.make_closure_ast(parameters, body, &closure_location)
     }
 
+    fn parse_closure_expression_body(&mut self) -> ExprsRes {
+        let expressions = self.parse_brace_block()?;
+        Ok(expressions)
+    }
+
     /// Should be called after the scanner has advanced past a left brace.
     /// Stops at the end or a right brace `}`, so the caller should validate the end character is `}`.
     ///
-    /// It possibly returns an empty vector for parsed expressions.
-    fn parse_closure_expression_body(&mut self) -> ExprsRes {
+    /// It possibly returns an empty vector for parsed expressions, which is also should be validated by the caller.
+    fn parse_brace_block(&mut self) -> ExprsRes {
         let mut expressions: Exprs = vec![];
 
         while let Some(token) = self.scanner.read() {

--- a/komi_parser/src/lib.rs
+++ b/komi_parser/src/lib.rs
@@ -90,11 +90,99 @@ impl<'a> Parser<'a> {
             TokenKind::Bang => self.parse_bang_prefix_expression(&first_token.location),
             TokenKind::LParen => self.parse_grouped_expression(first_token),
             TokenKind::Closure => self.parse_closure_expression(&first_token.location),
+            TokenKind::IfBranch => self.parse_branch_expression(&first_token.location),
             _ => {
                 let location = first_token.location;
                 Err(ParseError::new(ParseErrorKind::InvalidExprStart, location))
             }
         }
+    }
+
+    fn parse_branch_expression(&mut self, keyword_location: &Range) -> AstRes {
+        // Parse a predicate
+        let first_location = self.scanner.locate();
+        let Some(first_token) = self.scanner.read_and_advance() else {
+            let branch_location = Range::new(keyword_location.begin, first_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoPredicate, branch_location));
+        };
+        let predicate = self.parse_expression(first_token, &Bp::LOWEST)?;
+
+        // Expect an opening brace
+        let conseq_opening_brace_location = self.scanner.locate();
+        let Some(token) = self.scanner.read_and_advance() else {
+            let branch_location = Range::new(keyword_location.begin, conseq_opening_brace_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoConseqBlock, branch_location));
+        };
+        if token.kind != TokenKind::LBrace {
+            let branch_location = conseq_opening_brace_location;
+            return Err(ParseError::new(ParseErrorKind::NoOpeningBraceInConseq, branch_location));
+        }
+
+        // Parse a consequence
+        let consequence = self.parse_branch_expression_consequence()?;
+
+        // Expect a closing brace
+        let conseq_closing_brace_location = self.scanner.locate();
+        let Some(_token) = self.scanner.read_and_advance() else {
+            let conseq_location = Range::new(conseq_opening_brace_location.begin, conseq_closing_brace_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoClosingBraceInConseq, conseq_location));
+        };
+
+        // Expect a non-empty consequence
+        if consequence.len() == 0 {
+            let conseq_location = Range::new(conseq_opening_brace_location.begin, conseq_closing_brace_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoExprConseq, conseq_location));
+        }
+
+        // Expect a else-branch keyword
+        let else_keyword_location = self.scanner.locate();
+        let Some(token) = self.scanner.read_and_advance() else {
+            let branch_location = Range::new(keyword_location.begin, else_keyword_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoAlternBlock, branch_location));
+        };
+        if token.kind != TokenKind::ElseBranch {
+            return Err(ParseError::new(ParseErrorKind::NoAlternKeyword, else_keyword_location));
+        }
+
+        // Expect an opening brace
+        let altern_opening_brace_location = self.scanner.locate();
+        let Some(token) = self.scanner.read_and_advance() else {
+            let else_location = Range::new(else_keyword_location.begin, altern_opening_brace_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoAlternBlock, else_location));
+        };
+        if token.kind != TokenKind::LBrace {
+            return Err(ParseError::new(ParseErrorKind::NoOpeningBraceInAltern, token.location));
+        }
+
+        // Parse a alternative
+        let alternative = self.parse_branch_expression_alternative()?;
+
+        // Expect a closing brace
+        let altern_closing_brace_location = self.scanner.locate();
+        let Some(_token) = self.scanner.read_and_advance() else {
+            let else_location = Range::new(altern_opening_brace_location.begin, altern_closing_brace_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoClosingBraceInAltern, else_location));
+        };
+
+        // Expect a non-empty alternative
+        if alternative.len() == 0 {
+            let else_location = Range::new(altern_opening_brace_location.begin, altern_closing_brace_location.end);
+            return Err(ParseError::new(ParseErrorKind::NoExprInAltern, else_location));
+        }
+
+        let branch_location = Range::new(keyword_location.begin, altern_closing_brace_location.end);
+        let branch = Ast::new(AstKind::Branch { predicate, consequence, alternative }, branch_location);
+        Ok(Box::new(branch))
+    }
+
+    fn parse_branch_expression_consequence(&mut self) -> ExprsRes {
+        let expressions = self.parse_brace_block()?;
+        Ok(expressions)
+    }
+
+    fn parse_branch_expression_alternative(&mut self) -> ExprsRes {
+        let expressions = self.parse_brace_block()?;
+        Ok(expressions)
     }
 
     /// Parses characters into a closure-expression AST, with the location `keyword_location` of the closure keyword.
@@ -114,16 +202,17 @@ impl<'a> Parser<'a> {
         // Check if the body is empty here, to locate the closure.
         if body.len() == 0 {
             let closure_location = Range::new(keyword_location.begin, token_location.end);
-            return Err(ParseError::new(
-                ParseErrorKind::NoExpressionInClosureBody,
-                closure_location,
-            ));
+            return Err(ParseError::new(ParseErrorKind::NoExprInClosureBody, closure_location));
         }
 
         let closure_location = Range::new(keyword_location.begin, token_location.end);
         self.make_closure_ast(parameters, body, &closure_location)
     }
 
+    /// Should be called after the scanner has advanced past a left brace.
+    /// Stops at the end or a right brace `}`, so the caller should validate the end character is `}`.
+    ///
+    /// It possibly returns an empty vector for parsed expressions, which is also should be validated by the caller.
     fn parse_closure_expression_body(&mut self) -> ExprsRes {
         let expressions = self.parse_brace_block()?;
         Ok(expressions)
@@ -2463,7 +2552,7 @@ mod tests {
                 TokenKind::RBrace,
             ),
         ],
-        mkerr!(NoExpressionInClosureBody, str_loc!("", "함수 {}"))
+        mkerr!(NoExprInClosureBody, str_loc!("", "함수 {}"))
     )]
     #[case::single_parameter_and_empty_body(
         // Represents `함수 사과 {}`.
@@ -2481,7 +2570,7 @@ mod tests {
                 TokenKind::RBrace,
             ),
         ],
-        mkerr!(NoExpressionInClosureBody, str_loc!("", "함수 사과 {}"))
+        mkerr!(NoExprInClosureBody, str_loc!("", "함수 사과 {}"))
     )]
     #[case::multiple_params_and_empty_body(
         // Represents `함수 사과, 오렌지, 바나나 {}`.
@@ -2511,7 +2600,7 @@ mod tests {
                 TokenKind::RBrace,
             ),
         ],
-        mkerr!(NoExpressionInClosureBody, str_loc!("", "함수 사과, 오렌지, 바나나 {}"))
+        mkerr!(NoExprInClosureBody, str_loc!("", "함수 사과, 오렌지, 바나나 {}"))
     )]
     fn empty_body_closure(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
         assert_parse_fail!(&tokens, error);
@@ -2709,6 +2798,356 @@ mod tests {
         mkerr!(NoCommaInCallArgs, str_loc!("사과(1 ", "2"))
     )]
     fn wrong_comma_call(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
+        assert_parse_fail!(&tokens, error);
+    }
+
+    #[rstest]
+    #[case::conseq_and_altern(
+        // Represents `만약 참 { 1 } 아니면 { 2 }`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 { ", "2"),
+                TokenKind::Number(2.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 { 2 ", "}"),
+                TokenKind::RBrace,
+            ),
+        ],
+        mkast!(prog loc str_loc!("", "만약 참 { 1 } 아니면 { 2 }"), vec![
+            mkast!(branch loc str_loc!("", "만약 참 { 1 } 아니면 { 2 }"),
+                pred mkast!(boolean true, loc str_loc!("만약 ", "참")),
+                conseq vec![
+                    mkast!(num 1.0, loc str_loc!("만약 참 { ", "1")),
+                ],
+                altern vec![
+                    mkast!(num 2.0, loc str_loc!("만약 참 { 1 } 아니면 { ", "2")),
+                ],
+            )
+        ])
+    )]
+    #[case::nested_conseq(
+        // Represents `만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 { 3 }`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { ", "2"),
+                TokenKind::Number(2.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 } ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 } } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 { ", "3"),
+                TokenKind::Number(3.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 { 3 ", "}"),
+                TokenKind::RBrace,
+            ),
+        ],
+        mkast!(prog loc str_loc!("", "만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 { 3 }"), vec![
+            mkast!(branch loc str_loc!("", "만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 { 3 }"),
+                pred mkast!(boolean true, loc str_loc!("만약 ", "참")),
+                conseq vec![
+                    mkast!(branch loc str_loc!("만약 참 { ", "만약 참 { 1 } 아니면 { 2 }"),
+                        pred mkast!(boolean true, loc str_loc!("만약 참 { 만약 ", "참")),
+                        conseq vec![
+                            mkast!(num 1.0, loc str_loc!("만약 참 { 만약 참 { ", "1")),
+                        ],
+                        altern vec![
+                            mkast!(num 2.0, loc str_loc!("만약 참 { 만약 참 { 1 } 아니면 { ", "2")),
+                        ],
+                    ),
+                ],
+                altern vec![
+                    mkast!(num 3.0, loc str_loc!("만약 참 { 만약 참 { 1 } 아니면 { 2 } } 아니면 { ", "3")),
+                ],
+            )
+        ])
+    )]
+    fn branch(#[case] tokens: Vec<Token>, #[case] expected: Box<Ast>) {
+        assert_parse!(&tokens, expected);
+    }
+
+    #[rstest]
+    #[case::no_predicate(
+        // Represents `만약`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+        ],
+        mkerr!(NoPredicate, str_loc!("", "만약"))
+    )]
+    #[case::no_conseq_block(
+        // Represents `만약 참`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+        ],
+        mkerr!(NoConseqBlock, str_loc!("", "만약 참"))
+    )]
+    #[case::no_conseq_opening_brace(
+        // Represents `만약 참 1`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "1"),
+                TokenKind::Number(1.0),
+            ),
+        ],
+        mkerr!(NoOpeningBraceInConseq, str_loc!("만약 참 ", "1"))
+    )]
+    #[case::no_conseq_closing_brace(
+        // Represents `만약 참 {`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+        ],
+        mkerr!(NoClosingBraceInConseq, str_loc!("만약 참 ", "{"))
+    )]
+    #[case::empty_conseq(
+        // Represents `만약 참 { }`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "}"),
+                TokenKind::RBrace,
+            ),
+        ],
+        mkerr!(NoExprConseq, str_loc!("만약 참 ", "{ }"))
+    )]
+    #[case::no_altern_block(
+        // Represents `만약 참 { 1 }`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+        ],
+        mkerr!(NoAlternBlock, str_loc!("", "만약 참 { 1 }"))
+    )]
+    #[case::no_altern_keyword(
+        // Represents `만약 참 { 1 } 1`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } ", "1"),
+                TokenKind::Number(1.0),
+            ),
+        ],
+        mkerr!(NoAlternKeyword, str_loc!("만약 참 { 1 } ", "1"))
+    )]
+    #[case::no_altern_block(
+        // Represents `만약 참 { 1 } 아니면 `.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+        ],
+        mkerr!(NoAlternBlock, str_loc!("만약 참 { 1 } ", "아니면"))
+    )]
+    #[case::no_altern_opening_brace(
+        // Represents `만약 참 { 1 } 아니면 2`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 ", "2"),
+                TokenKind::Number(2.0),
+            ),
+        ],
+        mkerr!(NoOpeningBraceInAltern, str_loc!("만약 참 { 1 } 아니면 ", "2"))
+    )]
+    #[case::no_altern_closing_brace(
+        // Represents `만약 참 { 1 } 아니면 {`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 ", "{"),
+                TokenKind::LBrace,
+            ),
+        ],
+        mkerr!(NoClosingBraceInAltern, str_loc!("만약 참 { 1 } 아니면 ", "{"))
+    )]
+    #[case::empty_altern(
+        // Represents `만약 참 { 1 } 아니면 { }`.
+        vec![
+            mktoken!(str_loc!("", "만약"),
+                TokenKind::IfBranch,
+            ),
+            mktoken!(str_loc!("만약 ", "참"),
+                TokenKind::Bool(true),
+            ),
+            mktoken!(str_loc!("만약 참 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { ", "1"),
+                TokenKind::Number(1.0),
+            ),
+            mktoken!(str_loc!("만약 참 { 1 ", "}"),
+                TokenKind::RBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } ", "아니면"),
+                TokenKind::ElseBranch,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 ", "{"),
+                TokenKind::LBrace,
+            ),
+            mktoken!(str_loc!("만약 참 { 1 } 아니면 { ", "}"),
+                TokenKind::RBrace,
+            ),
+        ],
+        mkerr!(NoExprInAltern, str_loc!("만약 참 { 1 } 아니면 ", "{ }"))
+    )]
+    fn invalid_branch(#[case] tokens: Vec<Token>, #[case] error: ParseError) {
         assert_parse_fail!(&tokens, error);
     }
 

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -34,6 +34,7 @@ pub enum AstKind {
     InfixPercentEquals { left: Expr, right: Expr },
     Closure { parameters: Ids, body: Exprs },
     Call { target: Expr, arguments: Exprs },
+    Branch { predicate: Expr, consequence: Exprs, alternative: Exprs },
 }
 
 /// An abstract syntax tree, or AST produced during parsing.

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -52,6 +52,7 @@ impl Ast {
 
 /// Makes an AST with the kind and the location specified by four numbers.
 /// Helps write an AST declaratively.
+// TODO: remove old version
 #[macro_export]
 macro_rules! mkast {
     (prog loc $br:expr, $bc:expr, $er:expr, $ec: expr, $exprs:expr) => {
@@ -107,6 +108,12 @@ macro_rules! mkast {
     };
     (call loc $range:expr, target $target:expr, args $args:expr $(,)?) => {
         Box::new(Ast::new(AstKind::Call { target: $target, arguments: $args }, $range))
+    };
+    (branch loc $range:expr, pred $pred:expr, conseq $conseq:expr, altern $altern:expr $(,)?) => {
+        Box::new(Ast::new(
+            AstKind::Branch { predicate: $pred, consequence: $conseq, alternative: $altern },
+            $range,
+        ))
     };
     (num $val:expr, loc $br:expr, $bc:expr, $er:expr, $ec: expr) => {
         Box::new(Ast::new(AstKind::Number($val), Range::from_nums($br, $bc, $er, $ec)))

--- a/komi_syntax/src/ast/mod.rs
+++ b/komi_syntax/src/ast/mod.rs
@@ -1,33 +1,39 @@
 use komi_util::location::Range;
 use komi_util::str_segment::StrSegment;
 
+type Expr = Box<Ast>;
+type Exprs = Vec<Expr>;
+type Id = String;
+type Ids = Vec<Id>;
+type StrSegments = Vec<StrSegment>;
+
 /// Kinds of AST produced during parsing.
 /// Serves as the interface between a parser and its user.
 #[derive(Debug, PartialEq, Clone)]
 pub enum AstKind {
-    Program { expressions: Vec<Box<Ast>> },
+    Program { expressions: Exprs },
     Number(f64),
     Bool(bool),
-    Str(Vec<StrSegment>),
-    Identifier(String),
-    PrefixPlus { operand: Box<Ast> },
-    PrefixMinus { operand: Box<Ast> },
-    PrefixBang { operand: Box<Ast> },
-    InfixPlus { left: Box<Ast>, right: Box<Ast> },
-    InfixMinus { left: Box<Ast>, right: Box<Ast> },
-    InfixAsterisk { left: Box<Ast>, right: Box<Ast> },
-    InfixSlash { left: Box<Ast>, right: Box<Ast> },
-    InfixPercent { left: Box<Ast>, right: Box<Ast> },
-    InfixConjunct { left: Box<Ast>, right: Box<Ast> },
-    InfixDisjunct { left: Box<Ast>, right: Box<Ast> },
-    InfixEquals { left: Box<Ast>, right: Box<Ast> },
-    InfixPlusEquals { left: Box<Ast>, right: Box<Ast> },
-    InfixMinusEquals { left: Box<Ast>, right: Box<Ast> },
-    InfixAsteriskEquals { left: Box<Ast>, right: Box<Ast> },
-    InfixSlashEquals { left: Box<Ast>, right: Box<Ast> },
-    InfixPercentEquals { left: Box<Ast>, right: Box<Ast> },
-    Closure { parameters: Vec<String>, body: Vec<Box<Ast>> },
-    Call { target: Box<Ast>, arguments: Vec<Box<Ast>> },
+    Str(StrSegments),
+    Identifier(Id),
+    PrefixPlus { operand: Expr },
+    PrefixMinus { operand: Expr },
+    PrefixBang { operand: Expr },
+    InfixPlus { left: Expr, right: Expr },
+    InfixMinus { left: Expr, right: Expr },
+    InfixAsterisk { left: Expr, right: Expr },
+    InfixSlash { left: Expr, right: Expr },
+    InfixPercent { left: Expr, right: Expr },
+    InfixConjunct { left: Expr, right: Expr },
+    InfixDisjunct { left: Expr, right: Expr },
+    InfixEquals { left: Expr, right: Expr },
+    InfixPlusEquals { left: Expr, right: Expr },
+    InfixMinusEquals { left: Expr, right: Expr },
+    InfixAsteriskEquals { left: Expr, right: Expr },
+    InfixSlashEquals { left: Expr, right: Expr },
+    InfixPercentEquals { left: Expr, right: Expr },
+    Closure { parameters: Ids, body: Exprs },
+    Call { target: Expr, arguments: Exprs },
 }
 
 /// An abstract syntax tree, or AST produced during parsing.

--- a/komi_syntax/src/error/parse/mod.rs
+++ b/komi_syntax/src/error/parse/mod.rs
@@ -28,7 +28,27 @@ pub enum ParseErrorKind {
     /// Something else appears where the comma would be in the call arguments, such as `2` in `사과(1 2)`.
     NoCommaInCallArgs,
     /// A closure body is empty, which should not, such as `함수 {}`.
-    NoExpressionInClosureBody,
+    NoExprInClosureBody,
+    /// No predicate in a branch expression, such as `만약`.
+    NoPredicate,
+    /// No consequence in a branch expression, such as `만약 참`.
+    NoConseqBlock,
+    /// A consequence block does not begin with a opening brace `{`, such as `1` in `만약 참 1`.
+    NoOpeningBraceInConseq,
+    /// A consequence block does not end with a closing brace `}`, such as `만약 참 { 1`.
+    NoClosingBraceInConseq,
+    /// A consequence block is empty, such as `만약 참 {}`.
+    NoExprConseq,
+    /// No alternative in a branch expression, such as `만약 참 { 1 }`.
+    NoAlternBlock,
+    /// No alternative in a branch expression, such as `2` in `만약 참 { 1 } 2`.
+    NoAlternKeyword,
+    /// An alternative block does not begin with a opening brace `{`, such as `2` in `만약 참 { 1 } 아니면 2`.
+    NoOpeningBraceInAltern,
+    /// An alternative block does not closed with a closing brace `}`, such as `만약 참 { 1 } 아니면 { 2`.
+    NoClosingBraceInAltern,
+    /// An alternative block does empty, such as `만약 참 { 1 } 아니면 {}`.
+    NoExprInAltern,
     /// An unexpected error due to incorrect expression parsing. Should not occur.
     UnexpectedExprInfix,
 }
@@ -49,7 +69,17 @@ impl fmt::Display for ParseErrorKind {
             ParseErrorKind::NoClosingBraceInClosureBody => "NoClosingBraceInClosureBody",
             ParseErrorKind::NoClosingParenInCallArgs => "NoClosingParenInCallArgs",
             ParseErrorKind::NoCommaInCallArgs => "NoCommaInCallArgs",
-            ParseErrorKind::NoExpressionInClosureBody => "NoExpressionInClosureBody",
+            ParseErrorKind::NoExprInClosureBody => "NoExprInClosureBody",
+            ParseErrorKind::NoPredicate => "NoPredicate",
+            ParseErrorKind::NoConseqBlock => "NoConseqBlock",
+            ParseErrorKind::NoOpeningBraceInConseq => "NoOpeningBraceInConseq",
+            ParseErrorKind::NoClosingBraceInConseq => "NoClosingBraceInConseq",
+            ParseErrorKind::NoExprConseq => "NoExprConseq",
+            ParseErrorKind::NoAlternBlock => "NoAlternBlock",
+            ParseErrorKind::NoAlternKeyword => "NoAlternKeyword",
+            ParseErrorKind::NoOpeningBraceInAltern => "NoOpeningBraceInAltern",
+            ParseErrorKind::NoClosingBraceInAltern => "NoClosingBraceInAltern",
+            ParseErrorKind::NoExprInAltern => "NoExprInAltern",
             ParseErrorKind::UnexpectedExprInfix => "UnexpectedExprInfix",
         };
         write!(f, "{}", s)

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -248,7 +248,7 @@ mod tests {
             test_error!(closure_body_not_closed, "함수 {1", "ParseError", "NoClosingBraceInClosureBody", loc str_loc!("함수 {1", ""));
             test_error!(invalid_call_not_closed, "함수 {1}(", "ParseError", "NoClosingParenInCallArgs", loc str_loc!("", "함수 {1}("));
             test_error!(missing_comma_in_call_args, "함수 {1}(1 2", "ParseError", "NoCommaInCallArgs", loc str_loc!("함수 {1}(1 ", "2"));
-            test_error!(empty_closure_body, "함수 {}", "ParseError", "NoExpressionInClosureBody", loc str_loc!("", "함수 {}"));
+            test_error!(empty_closure_body, "함수 {}", "ParseError", "NoExprInClosureBody", loc str_loc!("", "함수 {}"));
         }
 
         mod eval {


### PR DESCRIPTION
now the parser can parse branch expressions and nested ones, but not the `else-if` (which is a to-do).