### PR TITLE
evaluate addition and multiplication on strings

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
     #[rstest]
     #[case::addition_assignment_to_bool_id(
         "a=참 a+=1",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 4, 0, 5)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumOrStrInfixLeftOperand, Range::from_nums(0, 4, 0, 5)))
     )]
     #[case::subtraction_assignment_to_bool_id(
         "a=참 a-=1",
@@ -312,7 +312,7 @@ mod tests {
     )]
     #[case::addition_assignment_with_bool(
         "a=1 a+=참",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 7, 0, 8)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixRightOperand, Range::from_nums(0, 7, 0, 8)))
     )]
     #[case::subtraction_assignment_with_bool(
         "a=1 a-=참",

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -296,7 +296,7 @@ mod tests {
     )]
     #[case::subtraction_assignment_to_bool_id(
         "a=참 a-=1",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 4, 0, 5)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixLeftOperand, Range::from_nums(0, 4, 0, 5)))
     )]
     #[case::multiplication_assignment_to_bool_id(
         "a=참 a*=1",
@@ -304,11 +304,11 @@ mod tests {
     )]
     #[case::division_assignment_to_bool_id(
         "a=참 a/=1",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 4, 0, 5)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixLeftOperand, Range::from_nums(0, 4, 0, 5)))
     )]
     #[case::modular_assignment_to_bool_id(
         "a=참 a%=1",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 4, 0, 5)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixLeftOperand, Range::from_nums(0, 4, 0, 5)))
     )]
     #[case::addition_assignment_with_bool(
         "a=1 a+=참",
@@ -316,7 +316,7 @@ mod tests {
     )]
     #[case::subtraction_assignment_with_bool(
         "a=1 a-=참",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 7, 0, 8)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixRightOperand, Range::from_nums(0, 7, 0, 8)))
     )]
     #[case::multiplication_assignment_with_bool(
         "a=1 a*=참",
@@ -324,11 +324,11 @@ mod tests {
     )]
     #[case::division_assignment_with_bool(
         "a=1 a/=참",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 7, 0, 8)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixRightOperand, Range::from_nums(0, 7, 0, 8)))
     )]
     #[case::modular_assignment_with_bool(
         "a=1 a%=참",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 7, 0, 8)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixRightOperand, Range::from_nums(0, 7, 0, 8)))
     )]
     fn assignment_with_wrong_type(#[case] source: &str, #[case] error: ExecError) {
         assert_fail!(source, error);

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -300,7 +300,7 @@ mod tests {
     )]
     #[case::multiplication_assignment_to_bool_id(
         "a=참 a*=1",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 4, 0, 5)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumOrStrInfixLeftOperand, Range::from_nums(0, 4, 0, 5)))
     )]
     #[case::division_assignment_to_bool_id(
         "a=참 a/=1",
@@ -320,7 +320,7 @@ mod tests {
     )]
     #[case::multiplication_assignment_with_bool(
         "a=1 a*=참",
-        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixOperand, Range::from_nums(0, 7, 0, 8)))
+        ExecError::Eval(EvalError::new(EvalErrorKind::NonNumInfixRightOperand, Range::from_nums(0, 7, 0, 8)))
     )]
     #[case::division_assignment_with_bool(
         "a=1 a/=참",

--- a/komi_evaluator/src/ast_reducer/combinator_infix/combinator_infix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/combinator_infix/combinator_infix_reducer/mod.rs
@@ -27,7 +27,8 @@ where
         location,
         env,
         stdouts,
-        get_num_primitive,
+        get_left_num_primitive,
+        get_right_num_primitive,
         reduce_infix,
         get_kind,
     )
@@ -55,14 +56,20 @@ where
         env,
         stdouts,
         get_bool_primitive,
+        get_bool_primitive,
         reduce_infix,
         get_kind,
     )
 }
 
-fn get_num_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Result<f64, EvalError> {
+fn get_left_num_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Result<f64, EvalError> {
     #[allow(deprecated)]
-    util::get_num_primitive_or_error(ast, EvalErrorKind::NonNumInfixOperand, env, stdouts)
+    util::get_num_primitive_or_error(ast, EvalErrorKind::NonNumInfixLeftOperand, env, stdouts)
+}
+
+fn get_right_num_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Result<f64, EvalError> {
+    #[allow(deprecated)]
+    util::get_num_primitive_or_error(ast, EvalErrorKind::NonNumInfixRightOperand, env, stdouts)
 }
 
 fn get_bool_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Result<bool, EvalError> {
@@ -77,23 +84,25 @@ fn get_bool_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Re
 /// - `get_kind` specifies what kind to return from `z`.
 ///
 /// The location is determined by `location`.
-fn reduce<T, F, G, H>(
+fn reduce<T, F, G, H, I>(
     left: &Box<Ast>,
     right: &Box<Ast>,
     location: &Range,
     env: &mut Env,
     stdouts: &mut Stdout,
-    reduce_operand: F,
-    reduce_infix: G,
-    get_kind: H,
+    reduce_left_operand: F,
+    reduce_right_operand: G,
+    reduce_infix: H,
+    get_kind: I,
 ) -> ValRes
 where
     F: Fn(&Box<Ast>, &mut Env, &mut Stdout) -> Result<T, EvalError>,
-    G: Fn(T, T) -> T,
-    H: Fn(T) -> ValueKind,
+    G: Fn(&Box<Ast>, &mut Env, &mut Stdout) -> Result<T, EvalError>,
+    H: Fn(T, T) -> T,
+    I: Fn(T) -> ValueKind,
 {
-    let left_val = reduce_operand(left, env, stdouts)?;
-    let right_val = reduce_operand(right, env, stdouts)?;
+    let left_val = reduce_left_operand(left, env, stdouts)?;
+    let right_val = reduce_right_operand(right, env, stdouts)?;
     let infix_val = reduce_infix(left_val, right_val);
 
     let kind = get_kind(infix_val);

--- a/komi_evaluator/src/ast_reducer/combinator_infix/combinator_infix_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/combinator_infix/combinator_infix_reducer/mod.rs
@@ -61,10 +61,12 @@ where
 }
 
 fn get_num_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Result<f64, EvalError> {
+    #[allow(deprecated)]
     util::get_num_primitive_or_error(ast, EvalErrorKind::NonNumInfixOperand, env, stdouts)
 }
 
 fn get_bool_primitive(ast: &Box<Ast>, env: &mut Env, stdouts: &mut Stdout) -> Result<bool, EvalError> {
+    #[allow(deprecated)]
     util::get_bool_primitive_or_error(ast, EvalErrorKind::NonBoolInfixOperand, env, stdouts)
 }
 

--- a/komi_evaluator/src/ast_reducer/combinator_infix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/combinator_infix/mod.rs
@@ -7,22 +7,61 @@ mod combinator_infix_reducer;
 use super::util;
 use crate::ValRes;
 use crate::environment::Environment as Env;
+use crate::reduce_ast;
 use combinator_infix_reducer as reducer;
 use komi_syntax::ast::Ast;
-use komi_syntax::value::{Stdout, ValueKind};
+use komi_syntax::error::{EvalError, EvalErrorKind};
+use komi_syntax::value::{Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
 /// Reduces the operands `left` and `right` of a plus infix to a value.
 pub fn reduce_plus(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Env, stdouts: &mut Stdout) -> ValRes {
-    reducer::reduce_num(
-        left,
-        right,
-        location,
-        env,
-        stdouts,
-        |l, r| l + r,
-        |v| ValueKind::Number(v),
-    )
+    let left_val = reduce_ast(left, env, stdouts)?;
+
+    match left_val.kind {
+        ValueKind::Number(left_num) => reduce_plus_with_left_num(left_num, right, location, env, stdouts),
+        ValueKind::Str(left_str) => reduce_plus_with_left_str(left_str, right, location, env, stdouts),
+        _ => Err(EvalError::new(
+            EvalErrorKind::NonNumOrStrInfixLeftOperand,
+            left_val.location,
+        )),
+    }
+}
+
+fn reduce_plus_with_left_num(
+    left_num: f64,
+    right: &Box<Ast>,
+    location: &Range,
+    env: &mut Env,
+    stdouts: &mut Stdout,
+) -> ValRes {
+    let right_val = reduce_ast(right, env, stdouts)?;
+
+    match right_val.kind {
+        ValueKind::Number(right_num) => Ok(Value::new(ValueKind::Number(left_num + right_num), *location)),
+        _ => Err(EvalError::new(
+            EvalErrorKind::NonNumInfixRightOperand,
+            right_val.location,
+        )),
+    }
+}
+
+fn reduce_plus_with_left_str(
+    left_str: String,
+    right: &Box<Ast>,
+    location: &Range,
+    env: &mut Env,
+    stdouts: &mut Stdout,
+) -> ValRes {
+    let right_val = reduce_ast(right, env, stdouts)?;
+
+    match right_val.kind {
+        ValueKind::Str(right_str) => Ok(Value::new(ValueKind::Str(left_str + &right_str), *location)),
+        _ => Err(EvalError::new(
+            EvalErrorKind::NonNumInfixRightOperand,
+            right_val.location,
+        )),
+    }
 }
 
 /// Reduces the operands `left` and `right` of a minus infix to a value.

--- a/komi_evaluator/src/ast_reducer/combinator_infix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/combinator_infix/mod.rs
@@ -91,15 +91,59 @@ pub fn reduce_asterisk(
     env: &mut Env,
     stdouts: &mut Stdout,
 ) -> ValRes {
-    reducer::reduce_num(
-        left,
-        right,
-        location,
-        env,
-        stdouts,
-        |l, r| l * r,
-        |v| ValueKind::Number(v),
-    )
+    let left_val = reduce_ast(left, env, stdouts)?;
+
+    match left_val.kind {
+        ValueKind::Number(left_num) => reduce_asterisk_with_left_num(left_num, right, location, env, stdouts),
+        ValueKind::Str(left_str) => reduce_asterisk_with_left_str(left_str, right, location, env, stdouts),
+        _ => Err(EvalError::new(
+            EvalErrorKind::NonNumOrStrInfixLeftOperand,
+            left_val.location,
+        )),
+    }
+}
+
+fn reduce_asterisk_with_left_num(
+    left_num: f64,
+    right: &Box<Ast>,
+    location: &Range,
+    env: &mut Env,
+    stdouts: &mut Stdout,
+) -> ValRes {
+    let right_val = reduce_ast(right, env, stdouts)?;
+
+    match right_val.kind {
+        ValueKind::Number(right_num) => Ok(Value::new(ValueKind::Number(left_num * right_num), *location)),
+        _ => Err(EvalError::new(
+            EvalErrorKind::NonNumInfixRightOperand,
+            right_val.location,
+        )),
+    }
+}
+
+fn reduce_asterisk_with_left_str(
+    left_str: String,
+    right: &Box<Ast>,
+    location: &Range,
+    env: &mut Env,
+    stdouts: &mut Stdout,
+) -> ValRes {
+    let right_val = reduce_ast(right, env, stdouts)?;
+
+    match right_val.kind {
+        ValueKind::Number(right_num) if right_num < 0.0 || right_num.fract() != 0.0 => Err(EvalError::new(
+            EvalErrorKind::NonNonnegIntInfixRightOperand,
+            right_val.location,
+        )),
+        ValueKind::Number(right_num) => {
+            let right_num = right_num as usize; // Can be safely converted since a non-negative integer, as verified above
+            Ok(Value::new(ValueKind::Str(left_str.repeat(right_num)), *location))
+        }
+        _ => Err(EvalError::new(
+            EvalErrorKind::NonNumInfixRightOperand,
+            right_val.location,
+        )),
+    }
 }
 
 /// Reduces the operands `left` and `right` of a slash infix to a value.

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -615,7 +615,40 @@ mod tests {
             ]),
             mkval!(ValueKind::Number(2.0), str_loc!("", "6%4"))
         )]
-        fn arithmetic_infix(#[case] ast: Box<Ast>, #[case] expected: Value) {
+        fn arithmetic_infix_nums(#[case] ast: Box<Ast>, #[case] expected: Value) {
+            assert_eval!(&ast, expected);
+        }
+
+        #[rstest]
+        #[case::addition(
+            // Represents `"사과" + "오렌지"`.
+            mkast!(prog loc str_loc!("", "\"사과\" + \"오렌지\""), vec![
+                mkast!(infix InfixPlus, loc str_loc!("", "\"사과\" + \"오렌지\""),
+                    left mkast!(string loc str_loc!("", "\"사과\""), vec![
+                        mkstrseg!(Str, "사과", str_loc!("\"", "사과")),
+                    ]),
+                    right mkast!(string loc str_loc!("\"사과\" + ", "\"오렌지\""), vec![
+                        mkstrseg!(Str, "오렌지", str_loc!("\"사과\" = \"", "오렌지")),
+                    ]),
+                ),
+            ]),
+            mkval!(ValueKind::Str(String::from("사과오렌지")), str_loc!("", "\"사과\" + \"오렌지\""))
+        )]
+        /* TODO
+        #[case::multiplication(
+            // Represents `"사과" * 3`.
+            mkast!(prog loc str_loc!("", "\"사과\" * 3"), vec![
+                mkast!(infix InfixAsterisk, loc str_loc!("", "\"사과\" * 3"),
+                    left mkast!(string loc str_loc!("", "\"사과\""), vec![
+                        mkstrseg!(Str, "사과", str_loc!("\"", "사과")),
+                    ]),
+                    right mkast!(num 3.0, loc str_loc!("\"사과\" * ", "3")),
+                ),
+            ]),
+            mkval!(ValueKind::Str(String::from("사과사과사과")), str_loc!("", "\"사과\" * 3"))
+        )]
+        */
+        fn arithmetic_infix_strs(#[case] ast: Box<Ast>, #[case] expected: Value) {
             assert_eval!(&ast, expected);
         }
 
@@ -741,7 +774,7 @@ mod tests {
                     right mkast!(num 1.0, loc str_loc!("참 + ", "1")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("", "참")),
+            mkerr!(NonNumOrStrInfixLeftOperand, str_loc!("", "참")),
         )]
         #[case::right_bool_addition(
             // Represents `1 + 참`.
@@ -751,7 +784,7 @@ mod tests {
                     right mkast!(boolean true, loc str_loc!("1 + ", "참")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("1 + ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("1 + ", "참")),
         )]
         #[case::left_bool_subtraction(
             // Represents `참 - 1`.
@@ -987,7 +1020,7 @@ mod tests {
             ]),
             // Represents a binding for `사과` to `1`.
             root_env("사과", &mkval!(ValueKind::Number(1.0), range())),
-            mkerr!(NonNumInfixOperand, str_loc!("사과 += ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("사과 += ", "참")),
         )]
         #[case::num_id_minus_equals_bool(
             // Represents `사과 -= 참`.

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -792,7 +792,7 @@ mod tests {
                     right mkast!(num 1.0, loc str_loc!("참 - ", "1")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("", "참")),
+            mkerr!(NonNumInfixLeftOperand, str_loc!("", "참")),
         )]
         #[case::right_bool_subtraction(
             // Represents `1 - 참`.
@@ -802,7 +802,7 @@ mod tests {
                     right mkast!(boolean true, loc str_loc!("1 - ", "참")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("1 - ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("1 - ", "참")),
         )]
         #[case::left_bool_multiplication(
             // Represents `참 * 1`.
@@ -832,7 +832,7 @@ mod tests {
                     right mkast!(num 1.0, loc str_loc!("참 / ", "1")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("", "참")),
+            mkerr!(NonNumInfixLeftOperand, str_loc!("", "참")),
         )]
         #[case::right_bool_division(
             // Represents `1 / 참`.
@@ -842,7 +842,7 @@ mod tests {
                     right mkast!(boolean true, loc str_loc!("1 / ", "참")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("1 / ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("1 / ", "참")),
         )]
         #[case::left_bool_modular(
             // Represents `참 % 1`.
@@ -852,7 +852,7 @@ mod tests {
                     right mkast!(num 1.0, loc str_loc!("참 % ", "1")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("", "참")),
+            mkerr!(NonNumInfixLeftOperand, str_loc!("", "참")),
         )]
         #[case::right_bool_modular(
             // Represents `1 % 참`.
@@ -862,7 +862,7 @@ mod tests {
                     right mkast!(boolean true, loc str_loc!("1 % ", "참")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("1 % ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("1 % ", "참")),
         )]
         fn arithmetic_infix_with_wrong_type_operand(#[case] ast: Box<Ast>, #[case] error: EvalError) {
             assert_eval_fail!(&ast, error);
@@ -1030,7 +1030,7 @@ mod tests {
             ]),
             // Represents a binding for `사과` to `1`.
             root_env("사과", &mkval!(ValueKind::Number(1.0), range())),
-            mkerr!(NonNumInfixOperand, str_loc!("사과 -= ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("사과 -= ", "참")),
         )]
         #[case::num_id_asterisk_equals_bool(
             // Represents `사과 *= 참`.
@@ -1054,7 +1054,7 @@ mod tests {
             ]),
             // Represents a binding for `사과` to `1`.
             root_env("사과", &mkval!(ValueKind::Number(1.0), range())),
-            mkerr!(NonNumInfixOperand, str_loc!("사과 /= ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("사과 /= ", "참")),
         )]
         #[case::num_id_percent_equals_bool(
             // Represents `사과 %= 참`.
@@ -1066,7 +1066,7 @@ mod tests {
             ]),
             // Represents a binding for `사과` to `1`.
             root_env("사과", &mkval!(ValueKind::Number(1.0), range())),
-            mkerr!(NonNumInfixOperand, str_loc!("사과 %= ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("사과 %= ", "참")),
         )]
         fn combinating_equals_with_wrong_type(#[case] ast: Box<Ast>, #[case] mut env: Env, #[case] error: EvalError) {
             assert_eval_fail!(&ast, &mut env, error);

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -634,7 +634,6 @@ mod tests {
             ]),
             mkval!(ValueKind::Str(String::from("사과오렌지")), str_loc!("", "\"사과\" + \"오렌지\""))
         )]
-        /* TODO
         #[case::multiplication(
             // Represents `"사과" * 3`.
             mkast!(prog loc str_loc!("", "\"사과\" * 3"), vec![
@@ -647,7 +646,6 @@ mod tests {
             ]),
             mkval!(ValueKind::Str(String::from("사과사과사과")), str_loc!("", "\"사과\" * 3"))
         )]
-        */
         fn arithmetic_infix_strs(#[case] ast: Box<Ast>, #[case] expected: Value) {
             assert_eval!(&ast, expected);
         }
@@ -814,7 +812,7 @@ mod tests {
                     right mkast!(num 1.0, loc str_loc!("참 * ", "1")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("", "참")),
+            mkerr!(NonNumOrStrInfixLeftOperand, str_loc!("", "참")),
         )]
         #[case::right_bool_multiplication(
             // Represents `1 * 참`.
@@ -824,7 +822,7 @@ mod tests {
                     right mkast!(boolean true, loc str_loc!("1 * ", "참")),
                 ),
             ]),
-            mkerr!(NonNumInfixOperand, str_loc!("1 * ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("1 * ", "참")),
         )]
         #[case::left_bool_division(
             // Represents `참 / 1`.
@@ -1044,7 +1042,7 @@ mod tests {
             ]),
             // Represents a binding for `사과` to `1`.
             root_env("사과", &mkval!(ValueKind::Number(1.0), range())),
-            mkerr!(NonNumInfixOperand, str_loc!("사과 *= ", "참")),
+            mkerr!(NonNumInfixRightOperand, str_loc!("사과 *= ", "참")),
         )]
         #[case::num_id_slash_equals_bool(
             // Represents `사과 /= 참`.

--- a/komi_syntax/src/error/eval/mod.rs
+++ b/komi_syntax/src/error/eval/mod.rs
@@ -12,9 +12,19 @@ pub enum EvalErrorKind {
     /// A left-hand side value of an assignment expression is not identifier, such as `1 = 2`.
     NonIdLeftValInAssign,
     /// Expected a numeric value as an operand of an infix, but it isn't, such as `참` in `1 + 참`.
+    #[deprecated]
     NonNumInfixOperand,
     /// Expected a boolean value as an operand of an infix, but it isn't, such as `1` in `참 또는 1`.
+    #[deprecated]
     NonBoolInfixOperand,
+    /// Expected a numeric value as a left-hand side operand of an index, but it isn't, such as `참` in `참 - 1`.
+    NonNumInfixLeftOperand,
+    /// Expected a numeric or string value as a left-hand side operand of an index, but it isn't, such as `참` in `참 + 1`.
+    NonNumOrStrInfixLeftOperand,
+    /// Expected a numeric value as a right-hand side operand of an index, but it isn't, such as `참` in `1 + 참`.
+    NonNumInfixRightOperand,
+    /// Expected a string value as a right-hand side operand of an index, but it isn't, such as `1` in `"사과" + 1`.
+    NonStrInfixRightOperand,
     /// Expected a numeric value as an operand of a prefix, but it isn't, such as `참` in `+참`.
     NonNumPrefixOperand,
     /// Expected a boolean value as an operand of a prefix, but it isn't, such as `1` in `!1`.
@@ -33,8 +43,14 @@ impl fmt::Display for EvalErrorKind {
             EvalErrorKind::NoExpressions => "NoExpressions",
             EvalErrorKind::UndefinedIdentifier => "UndefinedIdentifier",
             EvalErrorKind::NonIdLeftValInAssign => "NonIdLeftValInAssign",
+            #[allow(deprecated)]
             EvalErrorKind::NonNumInfixOperand => "NonNumInfixOperand",
+            #[allow(deprecated)]
             EvalErrorKind::NonBoolInfixOperand => "NonBoolInfixOperand",
+            EvalErrorKind::NonNumInfixLeftOperand => "NonNumInfixLeftOperand",
+            EvalErrorKind::NonNumOrStrInfixLeftOperand => "NonNumOrStrInfixLeftOperand",
+            EvalErrorKind::NonNumInfixRightOperand => "NonNumInfixRightOperand",
+            EvalErrorKind::NonStrInfixRightOperand => "NonStrInfixRightOperand",
             EvalErrorKind::NonNumPrefixOperand => "NonNumPrefixOperand",
             EvalErrorKind::NonBoolPrefixOperand => "NonBoolPrefixOperand",
             EvalErrorKind::InvalidCallTarget => "InvalidCallTarget",

--- a/komi_syntax/src/error/eval/mod.rs
+++ b/komi_syntax/src/error/eval/mod.rs
@@ -25,6 +25,8 @@ pub enum EvalErrorKind {
     NonNumInfixRightOperand,
     /// Expected a string value as a right-hand side operand of an index, but it isn't, such as `1` in `"사과" + 1`.
     NonStrInfixRightOperand,
+    /// Expected a non-negative integer value as a right-hand side operand of an index, but it isn't, such as `-1.5` in `"사과" * -1.5`.
+    NonNonnegIntInfixRightOperand,
     /// Expected a numeric value as an operand of a prefix, but it isn't, such as `참` in `+참`.
     NonNumPrefixOperand,
     /// Expected a boolean value as an operand of a prefix, but it isn't, such as `1` in `!1`.
@@ -51,6 +53,8 @@ impl fmt::Display for EvalErrorKind {
             EvalErrorKind::NonNumOrStrInfixLeftOperand => "NonNumOrStrInfixLeftOperand",
             EvalErrorKind::NonNumInfixRightOperand => "NonNumInfixRightOperand",
             EvalErrorKind::NonStrInfixRightOperand => "NonStrInfixRightOperand",
+            // TODO: better name `NotNonneg...`?
+            EvalErrorKind::NonNonnegIntInfixRightOperand => "NonNonnegIntInfixRightOperadn",
             EvalErrorKind::NonNumPrefixOperand => "NonNumPrefixOperand",
             EvalErrorKind::NonBoolPrefixOperand => "NonBoolPrefixOperand",
             EvalErrorKind::InvalidCallTarget => "InvalidCallTarget",

--- a/komi_syntax/src/error/eval/mod.rs
+++ b/komi_syntax/src/error/eval/mod.rs
@@ -11,11 +11,7 @@ pub enum EvalErrorKind {
     UndefinedIdentifier,
     /// A left-hand side value of an assignment expression is not identifier, such as `1 = 2`.
     NonIdLeftValInAssign,
-    /// Expected a numeric value as an operand of an infix, but it isn't, such as `참` in `1 + 참`.
-    #[deprecated]
-    NonNumInfixOperand,
     /// Expected a boolean value as an operand of an infix, but it isn't, such as `1` in `참 또는 1`.
-    #[deprecated]
     NonBoolInfixOperand,
     /// Expected a numeric value as a left-hand side operand of an index, but it isn't, such as `참` in `참 - 1`.
     NonNumInfixLeftOperand,
@@ -45,9 +41,6 @@ impl fmt::Display for EvalErrorKind {
             EvalErrorKind::NoExpressions => "NoExpressions",
             EvalErrorKind::UndefinedIdentifier => "UndefinedIdentifier",
             EvalErrorKind::NonIdLeftValInAssign => "NonIdLeftValInAssign",
-            #[allow(deprecated)]
-            EvalErrorKind::NonNumInfixOperand => "NonNumInfixOperand",
-            #[allow(deprecated)]
             EvalErrorKind::NonBoolInfixOperand => "NonBoolInfixOperand",
             EvalErrorKind::NonNumInfixLeftOperand => "NonNumInfixLeftOperand",
             EvalErrorKind::NonNumOrStrInfixLeftOperand => "NonNumOrStrInfixLeftOperand",

--- a/komi_wasm/tests/test.rs
+++ b/komi_wasm/tests/test.rs
@@ -191,7 +191,7 @@ mod tests {
             test_exec!(division_assignment, "사과=6 사과/=4 사과", "1.5", "");
             test_exec!(modular_assignment, "사과=6 사과%=4 사과", "2", "");
 
-            test_error!(mixed_type, "사과=참 사과+=1", "EvalError", "NonNumInfixOperand", loc str_loc!("사과=참 ", "사과"));
+            test_error!(mixed_type, "사과=참 사과+=1", "EvalError", "NonNumOrStrInfixLeftOperand", loc str_loc!("사과=참 ", "사과"));
 
             test_exec!(
                 string_with_interpolation,
@@ -263,7 +263,7 @@ mod tests {
             test_error!(call_num, "1()", "EvalError", "InvalidCallTarget", loc str_loc!("", "1"));
             test_error!(undefined_identifier, "사과", "EvalError", "UndefinedIdentifier", loc str_loc!("", "사과"));
             test_error!(invalid_assignment_left, "1=1", "EvalError", "NonIdLeftValInAssign", loc str_loc!("", "1"));
-            test_error!(invalid_num_infix_operand, "참+1", "EvalError", "NonNumInfixOperand", loc str_loc!("", "참"));
+            test_error!(invalid_num_infix_operand, "참+1", "EvalError", "NonNumOrStrInfixLeftOperand", loc str_loc!("", "참"));
             test_error!(invalid_bool_infix_operand, "1 그리고 참", "EvalError", "NonBoolInfixOperand", loc str_loc!("", "1"));
             test_error!(invalid_num_prefix_operand, "+참", "EvalError", "NonNumPrefixOperand", loc str_loc!("+", "참"));
             test_error!(invalid_bool_prefix_operand, "!1", "EvalError", "NonBoolPrefixOperand", loc str_loc!("!", "1"));


### PR DESCRIPTION
the error system improved, here's why:
turns out that the error should be more specific, since not all types support addition and multiplication.
as the types of operands are verified during evaluation, the evaluator now returns an error indicating at which position (left- or right-hand side) the error occurs if an invalid type encountered.