### PR TITLE
return error when no arguments in builtin write

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -35,6 +35,7 @@ mod tests {
     use super::*;
     use komi_syntax::error::{EvalError, EvalErrorKind, LexError, LexErrorKind, ParseError, ParseErrorKind};
     use komi_util::location::Range;
+    use komi_util::str_loc;
     use rstest::rstest;
 
     /// Asserts a given source to be interpreted into the expected result with stdout.
@@ -383,5 +384,14 @@ mod tests {
     #[case::str_hangul("쓰기(\"사과\")", "2", "사과")]
     fn stdout(#[case] source: &str, #[case] expected_repr: String, #[case] expected_stdout: String) {
         assert_out!(source, expected_repr, expected_stdout);
+    }
+
+    #[rstest]
+    #[case::stdout_write_with_no_arg(
+        "쓰기()",
+        ExecError::Eval(EvalError::new(EvalErrorKind::BadNumArgs, str_loc!("", "쓰기()")))
+    )]
+    fn builtin_fail(#[case] source: &str, #[case] error: ExecError) {
+        assert_fail!(source, error);
     }
 }

--- a/komi_evaluator/src/ast_reducer/call/mod.rs
+++ b/komi_evaluator/src/ast_reducer/call/mod.rs
@@ -25,6 +25,7 @@ fn evaluate_builtin_func(builtin_func: BuiltinFunc, arguments: &Args, env: &mut 
     Ok(builtin_func(&arg_vals, stdouts))
 }
 
+// TODO: validate the number of arguments, and return BadNumArgs if not matched.
 fn evaluate_closure(
     parameters: Params,
     arguments: &Args,

--- a/komi_evaluator/src/ast_reducer/call/mod.rs
+++ b/komi_evaluator/src/ast_reducer/call/mod.rs
@@ -13,16 +13,22 @@ pub fn evaluate(target: &Box<Ast>, arguments: &Args, location: &Range, env: &mut
         ValueKind::Closure { parameters, body, env: closure_env } => {
             evaluate_closure(parameters, arguments, body, env, closure_env, location, stdouts)
         }
-        ValueKind::BuiltinFunc(builtin_func) => evaluate_builtin_func(builtin_func, arguments, env, stdouts),
+        ValueKind::BuiltinFunc(builtin_func) => evaluate_builtin_func(builtin_func, arguments, env, location, stdouts),
         _ => Err(EvalError::new(EvalErrorKind::InvalidCallTarget, target.location)),
     }
 }
 
-fn evaluate_builtin_func(builtin_func: BuiltinFunc, arguments: &Args, env: &mut Env, stdouts: &mut Stdout) -> ValRes {
+fn evaluate_builtin_func(
+    builtin_func: BuiltinFunc,
+    arguments: &Args,
+    env: &mut Env,
+    location: &Range,
+    stdouts: &mut Stdout,
+) -> ValRes {
     let arg_vals_res: ValsRes = arguments.iter().map(|arg| reduce_ast(arg, env, stdouts)).collect();
     let arg_vals = arg_vals_res?;
 
-    builtin_func(&arg_vals, stdouts)
+    builtin_func(location, &arg_vals, stdouts)
 }
 
 // TODO: validate the number of arguments, and return BadNumArgs if not matched.

--- a/komi_evaluator/src/ast_reducer/call/mod.rs
+++ b/komi_evaluator/src/ast_reducer/call/mod.rs
@@ -22,7 +22,7 @@ fn evaluate_builtin_func(builtin_func: BuiltinFunc, arguments: &Args, env: &mut 
     let arg_vals_res: ValsRes = arguments.iter().map(|arg| reduce_ast(arg, env, stdouts)).collect();
     let arg_vals = arg_vals_res?;
 
-    Ok(builtin_func(&arg_vals, stdouts))
+    builtin_func(&arg_vals, stdouts)
 }
 
 // TODO: validate the number of arguments, and return BadNumArgs if not matched.

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -7,7 +7,7 @@ pub fn bind(env: &mut Env) -> () {
     env.set("쓰기", &Value::new(ValueKind::BuiltinFunc(stdout_write), Range::ORIGIN))
 }
 
-fn stdout_write(args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
+fn stdout_write(_location: &Range, args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
     let strs: Vec<String> = args.iter().map(|arg| arg.represent()).collect();
     let joined = strs.join(" ");
     let joined_len = joined.chars().count();

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -1,5 +1,6 @@
 use crate::Environment as Env;
 use crate::ValRes;
+use komi_syntax::error::{EvalError, EvalErrorKind};
 use komi_syntax::value::{Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
@@ -7,7 +8,11 @@ pub fn bind(env: &mut Env) -> () {
     env.set("쓰기", &Value::new(ValueKind::BuiltinFunc(stdout_write), Range::ORIGIN))
 }
 
-fn stdout_write(_location: &Range, args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
+fn stdout_write(location: &Range, args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
+    if args.len() == 0 {
+        return Err(EvalError::new(EvalErrorKind::BadNumArgs, *location));
+    }
+
     let strs: Vec<String> = args.iter().map(|arg| arg.represent()).collect();
     let joined = strs.join(" ");
     let joined_len = joined.chars().count();

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -1,4 +1,5 @@
 use crate::Environment as Env;
+use crate::ValRes;
 use komi_syntax::value::{Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
@@ -6,12 +7,12 @@ pub fn bind(env: &mut Env) -> () {
     env.set("쓰기", &Value::new(ValueKind::BuiltinFunc(stdout_write), Range::ORIGIN))
 }
 
-fn stdout_write(args: &Vec<Value>, stdouts: &mut Stdout) -> Value {
+fn stdout_write(args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
     let strs: Vec<String> = args.iter().map(|arg| arg.represent()).collect();
     let joined = strs.join(" ");
     let joined_len = joined.chars().count();
 
     stdouts.push(joined);
 
-    Value::new(ValueKind::Number(joined_len as f64), Range::ORIGIN)
+    Ok(Value::new(ValueKind::Number(joined_len as f64), Range::ORIGIN))
 }

--- a/komi_syntax/src/error/eval/mod.rs
+++ b/komi_syntax/src/error/eval/mod.rs
@@ -42,6 +42,8 @@ pub enum EvalErrorKind {
     InvalidCallTarget,
     /// Expected a boolean value as a predicate, but it isn't, such as `1` in `만약 1 { 2 } 아니면 { 3 }`.
     NonBoolPred,
+    /// The number of arguments is not the same with the one of parameters.
+    BadNumArgs,
 }
 
 pub type EvalError = EngineError<EvalErrorKind>;
@@ -68,6 +70,7 @@ impl fmt::Display for EvalErrorKind {
             EvalErrorKind::NonBoolPrefixOperand => "NonBoolPrefixOperand",
             EvalErrorKind::InvalidCallTarget => "InvalidCallTarget",
             EvalErrorKind::NonBoolPred => "NonBoolPred",
+            EvalErrorKind::BadNumArgs => "BadNumArgs",
         };
         write!(f, "{}", s)
     }

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -35,7 +35,7 @@ impl Value {
 }
 
 pub type Stdout = Vec<String>;
-pub type BuiltinFunc = fn(&Vec<Value>, &mut Stdout) -> Result<Value, EvalError>;
+pub type BuiltinFunc = fn(&Range, &Vec<Value>, &mut Stdout) -> Result<Value, EvalError>;
 
 #[macro_export]
 macro_rules! mkval {

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -1,6 +1,7 @@
 mod representation;
 
 use crate::ast::Ast;
+use crate::error::EvalError;
 use komi_util::environment::Environment;
 use komi_util::location::Range;
 use representation::Representer;
@@ -34,7 +35,7 @@ impl Value {
 }
 
 pub type Stdout = Vec<String>;
-pub type BuiltinFunc = fn(&Vec<Value>, &mut Stdout) -> Value;
+pub type BuiltinFunc = fn(&Vec<Value>, &mut Stdout) -> Result<Value, EvalError>;
 
 #[macro_export]
 macro_rules! mkval {


### PR DESCRIPTION
interal:
- fix for write builtin function to return `Result` type to handle errors