### PR TITLE
return error if not correct number of arguments

### DIFF
--- a/komi_evaluator/src/ast_reducer/call/mod.rs
+++ b/komi_evaluator/src/ast_reducer/call/mod.rs
@@ -31,7 +31,6 @@ fn evaluate_builtin_func(
     builtin_func(location, &arg_vals, stdouts)
 }
 
-// TODO: validate the number of arguments, and return BadNumArgs if not matched.
 fn evaluate_closure(
     parameters: Params,
     arguments: &Args,
@@ -41,6 +40,10 @@ fn evaluate_closure(
     location: &Range,
     stdouts: &mut Stdout,
 ) -> ValRes {
+    if arguments.len() != parameters.len() {
+        return Err(EvalError::new(EvalErrorKind::BadNumArgs, *location));
+    }
+
     let arg_vals_res: ValsRes = arguments
         .iter()
         .map(|arg| reduce_ast(arg, outer_env, stdouts))

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -268,6 +268,29 @@ mod tests {
             root_empty_env(),
             mkerr!(InvalidCallTarget, str_loc!("", "참")),
         )]
+        #[case::different_num_args_from_num_params(
+            // Represents `사과(1, 2)`.
+            mkast!(prog loc str_loc!("", "사과(1, 2)"), vec![
+                mkast!(call loc str_loc!("", "사과(1, 2)"),
+                    target mkast!(identifier "사과", loc str_loc!("", "사과")),
+                    args vec![
+                        mkast!(num 1.0, loc str_loc!("사과(", "1")),
+                        mkast!(num 2.0, loc str_loc!("사과(1, ", "2")),
+                    ],
+                ),
+            ]),
+            // Represents a binding for `사과` to `함수 오렌지 {오렌지}`.
+            root_env("사과", &Value::new(ValueKind::Closure {
+                parameters: vec![
+                    String::from("오렌지"),
+                ],
+                body: vec![
+                    mkast!(identifier "오렌지", loc range()),
+                ],
+                env: Env::new(),
+            }, range())),
+            mkerr!(BadNumArgs, str_loc!("", "사과(1, 2)")),
+        )]
         fn invalid_call(#[case] ast: Box<Ast>, #[case] mut env: Env, #[case] error: EvalError) {
             assert_eval_fail!(&ast, &mut env, error);
         }

--- a/komi_syntax/src/value/representation/mod.rs
+++ b/komi_syntax/src/value/representation/mod.rs
@@ -32,7 +32,6 @@ impl Representer {
     }
 
     fn represent_str(string: &String) -> String {
-        // TODO: wrap str with quotes
         string.clone()
     }
 


### PR DESCRIPTION
for example, error when calling with one argument a closure with two parameters.