### PR TITLE
abstract bulitin and custom closures

### DIFF
--- a/komi_evaluator/src/ast_reducer/call/mod.rs
+++ b/komi_evaluator/src/ast_reducer/call/mod.rs
@@ -1,27 +1,22 @@
-use crate::ast_reducer::{Args, Exprs, Params};
+use crate::ast_reducer::{Args, Params};
 use crate::environment::Environment as Env;
 use crate::{ValRes, ValsRes, reduce_ast};
 use komi_syntax::ast::{Ast, AstKind};
 use komi_syntax::error::{EvalError, EvalErrorKind};
-use komi_syntax::value::{BuiltinFunc, ClosureBodyKind, Stdout, Value, ValueKind};
+use komi_syntax::value::{ClosureBodyKind, Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
 pub fn evaluate(target: &Box<Ast>, arguments: &Args, location: &Range, env: &mut Env, stdouts: &mut Stdout) -> ValRes {
     let target_closure = reduce_ast(target, env, stdouts)?;
 
-    match target_closure.kind {
-        ValueKind::Closure { parameters, body, env: closure_env } => {
-            evaluate_closure(parameters, arguments, body, env, closure_env, location, stdouts)
-        }
-        ValueKind::BuiltinFunc(builtin_func) => evaluate_builtin_func(builtin_func, arguments, env, location, stdouts),
-        ValueKind::ClosureAlt { parameters, body, env: closure_env } => {
-            evaluate_closure_alt(parameters, arguments, body, env, closure_env, location, stdouts)
-        }
-        _ => Err(EvalError::new(EvalErrorKind::InvalidCallTarget, target.location)),
-    }
+    let ValueKind::Closure { parameters, body, env: closure_env } = target_closure.kind else {
+        return Err(EvalError::new(EvalErrorKind::InvalidCallTarget, target.location));
+    };
+
+    evaluate_closure(parameters, arguments, body, env, closure_env, location, stdouts)
 }
 
-fn evaluate_closure_alt(
+fn evaluate_closure(
     parameters: Params,
     arguments: &Args,
     body: ClosureBodyKind,
@@ -45,12 +40,12 @@ fn evaluate_closure_alt(
         inner_env.set(param, arg);
     }
 
-    let mut val = evaluate_closure_alt_body(body, &mut inner_env, location, &arg_vals, stdouts)?;
+    let mut val = evaluate_closure_body(body, &mut inner_env, location, &arg_vals, stdouts)?;
     val.location = *location;
     Ok(val)
 }
 
-fn evaluate_closure_alt_body(
+fn evaluate_closure_body(
     body: ClosureBodyKind,
     env: &mut Env,
     location: &Range,
@@ -69,49 +64,4 @@ fn evaluate_closure_alt_body(
             Ok(val)
         }
     }
-}
-
-fn evaluate_builtin_func(
-    builtin_func: BuiltinFunc,
-    arguments: &Args,
-    env: &mut Env,
-    location: &Range,
-    stdouts: &mut Stdout,
-) -> ValRes {
-    let arg_vals_res: ValsRes = arguments.iter().map(|arg| reduce_ast(arg, env, stdouts)).collect();
-    let arg_vals = arg_vals_res?;
-
-    builtin_func(location, &arg_vals, stdouts)
-}
-
-fn evaluate_closure(
-    parameters: Params,
-    arguments: &Args,
-    body: Exprs,
-    outer_env: &mut Env,
-    closure_env: Env,
-    location: &Range,
-    stdouts: &mut Stdout,
-) -> ValRes {
-    if arguments.len() != parameters.len() {
-        return Err(EvalError::new(EvalErrorKind::BadNumArgs, *location));
-    }
-
-    let arg_vals_res: ValsRes = arguments
-        .iter()
-        .map(|arg| reduce_ast(arg, outer_env, stdouts))
-        .collect();
-    let arg_vals = arg_vals_res?;
-
-    let mut inner_env = Env::from_outer(closure_env);
-    for (param, arg) in parameters.iter().zip(arg_vals.iter()) {
-        inner_env.set(param, arg);
-    }
-
-    let body_location = Range::new(body[0].location.begin, body[body.len() - 1].location.end);
-    let body_as_prog = Box::new(Ast::new(AstKind::Program { expressions: body }, body_location));
-    let mut val = reduce_ast(&body_as_prog, &mut inner_env, stdouts)?;
-
-    val.location = *location;
-    Ok(val)
 }

--- a/komi_evaluator/src/ast_reducer/leaf/mod.rs
+++ b/komi_evaluator/src/ast_reducer/leaf/mod.rs
@@ -2,7 +2,7 @@ use crate::ValRes;
 use crate::ast_reducer::{Exprs, Params};
 use crate::environment::Environment as Env;
 use komi_syntax::error::{EvalError, EvalErrorKind};
-use komi_syntax::value::{Value, ValueKind};
+use komi_syntax::value::{ClosureBodyKind, Value, ValueKind};
 use komi_util::location::Range;
 use komi_util::str_segment::{StrSegment, StrSegmentKind};
 
@@ -17,16 +17,7 @@ pub fn evaluate_identifier(name: &String, location: &Range, env: &Env) -> ValRes
         ValueKind::Bool(x) => Ok(Value::new(ValueKind::Bool(*x), *location)),
         ValueKind::Number(x) => Ok(Value::new(ValueKind::Number(*x), *location)),
         ValueKind::Str(x) => Ok(Value::new(ValueKind::Str(x.clone()), *location)),
-        ValueKind::Closure { parameters, body, env } => Ok(Value::new(
-            ValueKind::Closure {
-                parameters: parameters.clone(),
-                body: body.clone(),
-                env: env.clone(),
-            },
-            *location,
-        )),
-        ValueKind::BuiltinFunc(builtin_func) => Ok(Value::new(ValueKind::BuiltinFunc(*builtin_func), *location)),
-        ValueKind::ClosureAlt { .. } => {
+        ValueKind::Closure { .. } => {
             let mut v = x.clone();
             v.location = *location;
             Ok(v)
@@ -63,7 +54,7 @@ pub fn evaluate_closure(parameters: &Params, body: &Exprs, location: &Range, env
     Ok(Value::new(
         ValueKind::Closure {
             parameters: parameters.clone(),
-            body: body.clone(),
+            body: ClosureBodyKind::Ast(body.clone()),
             env: env.clone(),
         },
         *location,
@@ -74,6 +65,7 @@ pub fn evaluate_closure(parameters: &Params, body: &Exprs, location: &Range, env
 mod tests {
     use super::*;
     use fixtures::*;
+    use komi_syntax::value::ClosureBodyKind;
     use rstest::rstest;
 
     #[rstest]
@@ -125,7 +117,7 @@ mod tests {
             Ok(Value::new(
                 ValueKind::Closure {
                     parameters: vec![String::from("foo")],
-                    body: vec![],
+                    body: ClosureBodyKind::Ast(vec![]),
                     env: root_env()
                 },
                 range()

--- a/komi_evaluator/src/ast_reducer/leaf/mod.rs
+++ b/komi_evaluator/src/ast_reducer/leaf/mod.rs
@@ -25,6 +25,7 @@ pub fn evaluate_identifier(name: &String, location: &Range, env: &Env) -> ValRes
             *location,
         )),
         ValueKind::BuiltinFunc(builtin_func) => Ok(Value::new(ValueKind::BuiltinFunc(*builtin_func), *location)),
+        _ => todo!(),
     }
 }
 

--- a/komi_evaluator/src/ast_reducer/leaf/mod.rs
+++ b/komi_evaluator/src/ast_reducer/leaf/mod.rs
@@ -12,6 +12,7 @@ pub fn evaluate_identifier(name: &String, location: &Range, env: &Env) -> ValRes
         return Err(EvalError::new(EvalErrorKind::UndefinedIdentifier, *location));
     };
 
+    // TOOD: just change location and shorten code
     match &x.kind {
         ValueKind::Bool(x) => Ok(Value::new(ValueKind::Bool(*x), *location)),
         ValueKind::Number(x) => Ok(Value::new(ValueKind::Number(*x), *location)),
@@ -25,7 +26,11 @@ pub fn evaluate_identifier(name: &String, location: &Range, env: &Env) -> ValRes
             *location,
         )),
         ValueKind::BuiltinFunc(builtin_func) => Ok(Value::new(ValueKind::BuiltinFunc(*builtin_func), *location)),
-        _ => todo!(),
+        ValueKind::ClosureAlt { .. } => {
+            let mut v = x.clone();
+            v.location = *location;
+            Ok(v)
+        }
     }
 }
 

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -208,9 +208,9 @@ mod tests {
             // Represents a binding for `사과` to `함수 {1}`.
             root_env("사과", &Value::new(ValueKind::Closure {
                 parameters: vec![],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc range()),
-                ],
+                ]),
                 env: Env::new(),
             }, range())),
             mkval!(ValueKind::Number(1.0), str_loc!("", "사과()")),
@@ -224,7 +224,7 @@ mod tests {
                 ),
             ]),
             // Represents a binding for `사과` to `함수 {1}`.
-            root_env("사과", &Value::new(ValueKind::ClosureAlt {
+            root_env("사과", &Value::new(ValueKind::Closure {
                 parameters: vec![],
                 body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc range()),
@@ -250,12 +250,12 @@ mod tests {
                     String::from("오렌지"),
                     String::from("바나나"),
                 ],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     mkast!(infix InfixPlus, loc range(),
                         left mkast!(identifier "오렌지", loc range()),
                         right mkast!(identifier "바나나", loc range()),
                     ),
-                ],
+                ]),
                 env: Env::new(),
             }, range())),
             mkval!(ValueKind::Number(3.0), str_loc!("", "사과(1, 2)")),
@@ -303,9 +303,9 @@ mod tests {
                 parameters: vec![
                     String::from("오렌지"),
                 ],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     mkast!(identifier "오렌지", loc range()),
-                ],
+                ]),
                 env: Env::new(),
             }, range())),
             mkerr!(BadNumArgs, str_loc!("", "사과(1, 2)")),
@@ -344,16 +344,16 @@ mod tests {
             ]),
             root_env("사과", &Value::new(ValueKind::Closure {
                 parameters: vec![String::from("오렌지")],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc range()),
-                ],
+                ]),
                 env: Env::new()
             }, range())),
             Value::new(ValueKind::Closure {
                 parameters: vec![String::from("오렌지")],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc range()),
-                ],
+                ]),
                 env: Env::new()
             }, str_loc!("", "사과"))
         )]
@@ -362,14 +362,14 @@ mod tests {
             mkast!(prog loc str_loc!("", "사과"), vec![
                 mkast!(identifier "사과", loc str_loc!("", "사과")),
             ]),
-            root_env("사과", &Value::new(ValueKind::ClosureAlt {
+            root_env("사과", &Value::new(ValueKind::Closure {
                 parameters: vec![String::from("오렌지")],
                 body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc range()),
                 ]),
                 env: Env::new()
             }, range())),
-            Value::new(ValueKind::ClosureAlt {
+            Value::new(ValueKind::Closure {
                 parameters: vec![String::from("오렌지")],
                 body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc range()),
@@ -439,11 +439,11 @@ mod tests {
             ]),
             Value::new(ValueKind::Closure {
                 parameters: vec![String::from("사과"), String::from("오렌지"), String::from("바나나")],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     mkast!(num 1.0, loc str_loc!("함수 ", "사과")),
                     mkast!(num 2.0, loc str_loc!("함수 사과, ", "오렌지")),
                     mkast!(num 3.0, loc str_loc!("함수 사과, 오렌지, ", "바나나")),
-                ],
+                ]),
                 env: Env::new()
             }, str_loc!("", "함수 사과, 오렌지, 바나나 { 1 2 3 }"))
         )]
@@ -471,7 +471,7 @@ mod tests {
                 parameters: vec![
                     String::from("사과"),
                 ],
-                body: vec![
+                body: ClosureBodyKind::Ast(vec![
                     // Should contain the same AST with the closure body
                     mkast!(closure loc str_loc!("함수 사과 { ", "함수 오렌지 { 사과 + 오렌지 }"),
                         params vec![
@@ -484,7 +484,7 @@ mod tests {
                             ),
                         ],
                     ),
-                ],
+                ]),
                 env: Env::new()
             }, str_loc!("", "함수 사과 { 함수 오렌지 { 사과 + 오렌지 } }"))
         )]

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -84,7 +84,7 @@ mod tests {
     use fixtures::*;
     use komi_syntax::ast::AstKind;
     use komi_syntax::error::{EvalError, EvalErrorKind};
-    use komi_syntax::value::{Value, ValueKind};
+    use komi_syntax::value::{ClosureBodyKind, Value, ValueKind};
     use komi_syntax::{mkast, mkval};
     use komi_util::location::Range;
     use komi_util::str_segment::{StrSegment, StrSegmentKind};
@@ -336,6 +336,26 @@ mod tests {
                 body: vec![
                     mkast!(num 1.0, loc range()),
                 ],
+                env: Env::new()
+            }, str_loc!("", "사과"))
+        )]
+        #[case::closure_alt(
+            // Represents `사과`.
+            mkast!(prog loc str_loc!("", "사과"), vec![
+                mkast!(identifier "사과", loc str_loc!("", "사과")),
+            ]),
+            root_env("사과", &Value::new(ValueKind::ClosureAlt {
+                parameters: vec![String::from("오렌지")],
+                body: ClosureBodyKind::Ast(vec![
+                    mkast!(num 1.0, loc range()),
+                ]),
+                env: Env::new()
+            }, range())),
+            Value::new(ValueKind::ClosureAlt {
+                parameters: vec![String::from("오렌지")],
+                body: ClosureBodyKind::Ast(vec![
+                    mkast!(num 1.0, loc range()),
+                ]),
                 env: Env::new()
             }, str_loc!("", "사과"))
         )]

--- a/komi_evaluator/src/ast_reducer/mod.rs
+++ b/komi_evaluator/src/ast_reducer/mod.rs
@@ -215,6 +215,24 @@ mod tests {
             }, range())),
             mkval!(ValueKind::Number(1.0), str_loc!("", "사과()")),
         )]
+        #[case::call_id_alt(
+            // Represents `사과()`.
+            mkast!(prog loc str_loc!("", "사과()"), vec![
+                mkast!(call loc str_loc!("", "사과()"),
+                    target mkast!(identifier "사과", loc str_loc!("", "사과")),
+                    args vec![],
+                ),
+            ]),
+            // Represents a binding for `사과` to `함수 {1}`.
+            root_env("사과", &Value::new(ValueKind::ClosureAlt {
+                parameters: vec![],
+                body: ClosureBodyKind::Ast(vec![
+                    mkast!(num 1.0, loc range()),
+                ]),
+                env: Env::new(),
+            }, range())),
+            mkval!(ValueKind::Number(1.0), str_loc!("", "사과()")),
+        )]
         #[case::call_with_args(
             // Represents `사과(1, 2)`.
             mkast!(prog loc str_loc!("", "사과(1, 2)"), vec![

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -1,12 +1,23 @@
 use crate::Environment as Env;
 use crate::ValRes;
 use komi_syntax::error::{EvalError, EvalErrorKind};
-use komi_syntax::value::{Stdout, Value, ValueKind};
+use komi_syntax::value::{ClosureBodyKind, Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
 pub fn bind(env: &mut Env) -> () {
     env.set("쓰기", &Value::new(ValueKind::BuiltinFunc(stdout_write), Range::ORIGIN));
     env.set("타입", &Value::new(ValueKind::BuiltinFunc(get_type), Range::ORIGIN));
+    env.set(
+        "타입2",
+        &Value::new(
+            ValueKind::ClosureAlt {
+                parameters: vec![String::from("값")],
+                body: ClosureBodyKind::Native(get_type),
+                env: Env::new(),
+            },
+            Range::ORIGIN,
+        ),
+    );
 }
 
 fn stdout_write(location: &Range, args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
@@ -35,6 +46,7 @@ fn get_type(location: &Range, args: &Vec<Value>, _stdouts: &mut Stdout) -> ValRe
         ValueKind::Number(_) => "숫자",
         ValueKind::Str(_) => "문자",
         ValueKind::Closure { .. } | ValueKind::BuiltinFunc(_) => "함수",
+        _ => todo!(),
     };
 
     Ok(Value::new(ValueKind::Str(String::from(arg_type)), *location))

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -6,12 +6,21 @@ use komi_util::location::Range;
 
 pub fn bind(env: &mut Env) -> () {
     // Note: a dummy location used here, since it will be determined later when evaluated as an identifier.
-    env.set("쓰기", &Value::new(ValueKind::BuiltinFunc(stdout_write), Range::ORIGIN));
-    env.set("타입", &Value::new(ValueKind::BuiltinFunc(get_type), Range::ORIGIN));
     env.set(
-        "타입2",
+        "쓰기",
         &Value::new(
-            ValueKind::ClosureAlt {
+            ValueKind::Closure {
+                parameters: vec![String::from("내용")],
+                body: ClosureBodyKind::Native(stdout_write),
+                env: Env::new(),
+            },
+            Range::ORIGIN,
+        ),
+    );
+    env.set(
+        "타입",
+        &Value::new(
+            ValueKind::Closure {
                 parameters: vec![String::from("값")],
                 body: ClosureBodyKind::Native(get_type),
                 env: Env::new(),
@@ -22,7 +31,7 @@ pub fn bind(env: &mut Env) -> () {
 }
 
 fn stdout_write(location: &Range, args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
-    if args.len() == 0 {
+    if args.len() != 1 {
         return Err(EvalError::new(EvalErrorKind::BadNumArgs, *location));
     }
 
@@ -46,8 +55,7 @@ fn get_type(location: &Range, args: &Vec<Value>, _stdouts: &mut Stdout) -> ValRe
         ValueKind::Bool(_) => "불리언",
         ValueKind::Number(_) => "숫자",
         ValueKind::Str(_) => "문자",
-        ValueKind::Closure { .. } | ValueKind::BuiltinFunc(_) => "함수",
-        _ => todo!(),
+        ValueKind::Closure { .. } => "함수",
     };
 
     Ok(Value::new(ValueKind::Str(String::from(arg_type)), *location))

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -5,6 +5,7 @@ use komi_syntax::value::{ClosureBodyKind, Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
 pub fn bind(env: &mut Env) -> () {
+    // Note: a dummy location used here, since it will be determined later when evaluated as an identifier.
     env.set("쓰기", &Value::new(ValueKind::BuiltinFunc(stdout_write), Range::ORIGIN));
     env.set("타입", &Value::new(ValueKind::BuiltinFunc(get_type), Range::ORIGIN));
     env.set(

--- a/komi_evaluator/src/lib.rs
+++ b/komi_evaluator/src/lib.rs
@@ -102,12 +102,12 @@ mod tests {
     }
 
     #[test]
-    fn test_type2() {
-        let ast = mkast!(prog loc str_loc!("", "타입2(1)"), vec![
-            mkast!(call loc str_loc!("", "타입2(1)"),
-                target mkast!(identifier "타입2", loc str_loc!("", "타입2")),
+    fn test_type() {
+        let ast = mkast!(prog loc str_loc!("", "타입(1)"), vec![
+            mkast!(call loc str_loc!("", "타입(1)"),
+                target mkast!(identifier "타입", loc str_loc!("", "타입")),
                 args vec![
-                    mkast!(num 1.0, loc str_loc!("타입2(", "1")),
+                    mkast!(num 1.0, loc str_loc!("타입(", "1")),
                 ],
             ),
         ]);
@@ -120,7 +120,7 @@ mod tests {
             repr,
             Ok(Value::new(
                 ValueKind::Str(String::from("숫자")),
-                str_loc!("", "타입2(1)")
+                str_loc!("", "타입(1)")
             )),
         );
         assert_eq!(stdout, "");

--- a/komi_evaluator/src/lib.rs
+++ b/komi_evaluator/src/lib.rs
@@ -102,6 +102,31 @@ mod tests {
     }
 
     #[test]
+    fn test_type2() {
+        let ast = mkast!(prog loc str_loc!("", "타입2(1)"), vec![
+            mkast!(call loc str_loc!("", "타입2(1)"),
+                target mkast!(identifier "타입2", loc str_loc!("", "타입2")),
+                args vec![
+                    mkast!(num 1.0, loc str_loc!("타입2(", "1")),
+                ],
+            ),
+        ]);
+        let mut evaluator = Evaluator::new(&ast);
+
+        let repr = evaluator.eval();
+        let stdout = evaluator.flush();
+
+        assert_eq!(
+            repr,
+            Ok(Value::new(
+                ValueKind::Str(String::from("숫자")),
+                str_loc!("", "타입2(1)")
+            )),
+        );
+        assert_eq!(stdout, "");
+    }
+
+    #[test]
     fn test_stdout_id() {
         let ast = mkast!(prog loc 0, 0, 0, 5, vec![
             mkast!(infix InfixEquals, loc 0, 0, 0, 0,

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -28,7 +28,7 @@ pub enum ValueKind {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum ClosureBodyKind {
-    Ast(Box<Ast>),
+    Ast(Vec<Box<Ast>>),
     Native(BuiltinFunc),
 }
 

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -15,12 +15,6 @@ pub enum ValueKind {
     Str(String),
     Closure {
         parameters: Vec<String>,
-        body: Vec<Box<Ast>>,
-        env: Environment<Value>,
-    },
-    BuiltinFunc(BuiltinFunc),
-    ClosureAlt {
-        parameters: Vec<String>,
         body: ClosureBodyKind,
         env: Environment<Value>,
     },

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -19,6 +19,17 @@ pub enum ValueKind {
         env: Environment<Value>,
     },
     BuiltinFunc(BuiltinFunc),
+    ClosureAlt {
+        parameters: Vec<String>,
+        body: ClosureBodyKind,
+        env: Environment<Value>,
+    },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ClosureBodyKind {
+    Ast(Box<Ast>),
+    Native(BuiltinFunc),
 }
 
 /// A representation of the value produced during evaluation.

--- a/komi_syntax/src/value/representation/mod.rs
+++ b/komi_syntax/src/value/representation/mod.rs
@@ -8,7 +8,6 @@ impl Representer {
     pub const FALSE: &str = "거짓";
     pub const CLOSURE_KEYWORD: &str = "함수";
     pub const CLOSURE_BODY: &str = "{ ... }";
-    pub const BUILTIN_FUNC: &str = "(내장 함수)";
 
     pub fn represent(val: &Value) -> String {
         match &val.kind {
@@ -16,8 +15,6 @@ impl Representer {
             ValueKind::Bool(b) => Self::represent_bool(*b),
             ValueKind::Str(s) => Self::represent_str(s),
             ValueKind::Closure { parameters: p, .. } => Self::represent_closure(p),
-            ValueKind::BuiltinFunc(_) => Self::represent_builtin_func(),
-            _ => todo!(),
         }
     }
 
@@ -44,9 +41,5 @@ impl Representer {
 
         let repr = parts.join(" ");
         repr
-    }
-
-    fn represent_builtin_func() -> String {
-        String::from(Self::BUILTIN_FUNC)
     }
 }

--- a/komi_syntax/src/value/representation/mod.rs
+++ b/komi_syntax/src/value/representation/mod.rs
@@ -17,6 +17,7 @@ impl Representer {
             ValueKind::Str(s) => Self::represent_str(s),
             ValueKind::Closure { parameters: p, .. } => Self::represent_closure(p),
             ValueKind::BuiltinFunc(_) => Self::represent_builtin_func(),
+            _ => todo!(),
         }
     }
 


### PR DESCRIPTION
the builtin and custom closures were handled separately, but now they are merged into and evaluated as a single kind internally.
this refactoring reduces the extra handling code to distinguish when a (possibly builtin) closure is given.