### PR TITLE
evaluate method syntax call

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -42,7 +42,14 @@ mod tests {
     /// Helps write a test declaratively.
     macro_rules! assert_out {
         ($source:expr, $expected_repr:expr, $expected_stdout:expr) => {{
-            let out = execute($source).unwrap();
+            let executed = execute($source);
+            assert!(
+                executed.is_ok(),
+                "expected a execution result, but an error '{:?}'.",
+                executed
+            );
+
+            let out = executed.unwrap();
             let repr = out.representation;
             let stdout = out.stdout;
 
@@ -58,7 +65,14 @@ mod tests {
     /// Helps write a test declaratively.
     macro_rules! assert_fail {
         ($source:expr, $expected:expr) => {{
-            let err = execute($source).unwrap_err();
+            let executed = execute($source);
+            assert!(
+                executed.is_err(),
+                "expected a execution error, but success '{:?}'.",
+                executed
+            );
+
+            let err = executed.unwrap_err();
             assert_eq!(err, $expected, "received a result (left), but it isn't (right)",);
         }};
     }

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -391,7 +391,7 @@ mod tests {
 
     #[rstest]
     #[case::str_and_closure("\"사과\".함수 문자1, 문자2 { 문자1+문자2 }(\"오렌지\")", "사과오렌지", "")]
-    //#[case::str_and_builtin("\"사과\".타입()", "2", "쓰기")]
+    #[case::str_and_builtin("\"사과\".타입()", "문자", "")]
     fn method(#[case] source: &str, #[case] expected_repr: String, #[case] expected_stdout: String) {
         assert_out!(source, expected_repr, expected_stdout);
     }

--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -30,6 +30,7 @@ pub fn execute(source: &str) -> ExecRes {
     Ok(exec_out)
 }
 
+// TODO: write tests at the source-code level
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,6 +386,13 @@ mod tests {
     #[case::str_ascii("쓰기(\"foo\")", "3", "foo")]
     #[case::str_hangul("쓰기(\"사과\")", "2", "사과")]
     fn stdout(#[case] source: &str, #[case] expected_repr: String, #[case] expected_stdout: String) {
+        assert_out!(source, expected_repr, expected_stdout);
+    }
+
+    #[rstest]
+    #[case::str_and_closure("\"사과\".함수 문자1, 문자2 { 문자1+문자2 }(\"오렌지\")", "사과오렌지", "")]
+    //#[case::str_and_builtin("\"사과\".타입()", "2", "쓰기")]
+    fn method(#[case] source: &str, #[case] expected_repr: String, #[case] expected_stdout: String) {
         assert_out!(source, expected_repr, expected_stdout);
     }
 

--- a/komi_evaluator/src/ast_reducer/binder_infix/mod.rs
+++ b/komi_evaluator/src/ast_reducer/binder_infix/mod.rs
@@ -1,0 +1,30 @@
+use crate::ValRes;
+use crate::environment::Environment as Env;
+use crate::reduce_ast;
+use komi_syntax::ast::Ast;
+use komi_syntax::error::{EvalError, EvalErrorKind};
+use komi_syntax::value::{Stdout, Value, ValueKind};
+use komi_util::location::Range;
+
+pub fn reduce(left: &Box<Ast>, right: &Box<Ast>, location: &Range, env: &mut Env, stdouts: &mut Stdout) -> ValRes {
+    let left_val = reduce_ast(left, env, stdouts)?;
+    let right_val = reduce_ast(right, env, stdouts)?;
+    let ValueKind::Closure { parameters: closure_params, body, env: closure_env } = right_val.kind else {
+        return Err(EvalError::new(
+            EvalErrorKind::NotClosureRightOperand,
+            right_val.location,
+        ));
+    };
+    if closure_params.len() == 0 {
+        return Err(EvalError::new(EvalErrorKind::NoParamsToBind, right_val.location));
+    }
+
+    let mut env = closure_env.clone();
+    env.set(&closure_params[0], &left_val);
+    let params: Vec<String> = closure_params.into_iter().skip(1).collect();
+
+    Ok(Value::new(
+        ValueKind::Closure { parameters: params, body: body.clone(), env },
+        *location,
+    ))
+}

--- a/komi_evaluator/src/ast_reducer/call/mod.rs
+++ b/komi_evaluator/src/ast_reducer/call/mod.rs
@@ -3,7 +3,7 @@ use crate::environment::Environment as Env;
 use crate::{ValRes, ValsRes, reduce_ast};
 use komi_syntax::ast::{Ast, AstKind};
 use komi_syntax::error::{EvalError, EvalErrorKind};
-use komi_syntax::value::{ClosureBodyKind, Stdout, Value, ValueKind};
+use komi_syntax::value::{ClosureBodyKind, Stdout, ValueKind};
 use komi_util::location::Range;
 
 pub fn evaluate(target: &Box<Ast>, arguments: &Args, location: &Range, env: &mut Env, stdouts: &mut Stdout) -> ValRes {
@@ -40,18 +40,12 @@ fn evaluate_closure(
         inner_env.set(param, arg);
     }
 
-    let mut val = evaluate_closure_body(body, &mut inner_env, location, &arg_vals, stdouts)?;
+    let mut val = evaluate_closure_body(body, &mut inner_env, location, stdouts)?;
     val.location = *location;
     Ok(val)
 }
 
-fn evaluate_closure_body(
-    body: ClosureBodyKind,
-    env: &mut Env,
-    location: &Range,
-    arguments: &Vec<Value>,
-    stdouts: &mut Stdout,
-) -> ValRes {
+fn evaluate_closure_body(body: ClosureBodyKind, env: &mut Env, location: &Range, stdouts: &mut Stdout) -> ValRes {
     match body {
         ClosureBodyKind::Ast(body) => {
             let body_location = Range::new(body[0].location.begin, body[body.len() - 1].location.end);
@@ -60,7 +54,7 @@ fn evaluate_closure_body(
             Ok(val)
         }
         ClosureBodyKind::Native(f) => {
-            let val = f(location, arguments, stdouts)?;
+            let val = f(location, env, stdouts)?;
             Ok(val)
         }
     }

--- a/komi_evaluator/src/builtins/mod.rs
+++ b/komi_evaluator/src/builtins/mod.rs
@@ -1,6 +1,5 @@
 use crate::Environment as Env;
 use crate::ValRes;
-use komi_syntax::error::{EvalError, EvalErrorKind};
 use komi_syntax::value::{ClosureBodyKind, Stdout, Value, ValueKind};
 use komi_util::location::Range;
 
@@ -30,27 +29,18 @@ pub fn bind(env: &mut Env) -> () {
     );
 }
 
-fn stdout_write(location: &Range, args: &Vec<Value>, stdouts: &mut Stdout) -> ValRes {
-    if args.len() != 1 {
-        return Err(EvalError::new(EvalErrorKind::BadNumArgs, *location));
-    }
+fn stdout_write(location: &Range, env: &Env, stdouts: &mut Stdout) -> ValRes {
+    let arg = env.get("내용").unwrap();
+    let str = arg.represent();
+    let str_len = str.chars().count();
 
-    let strs: Vec<String> = args.iter().map(|arg| arg.represent()).collect();
-    let joined = strs.join(" ");
-    let joined_len = joined.chars().count();
+    stdouts.push(str);
 
-    stdouts.push(joined);
-
-    // TODO: fix location (meaning?)
-    Ok(Value::new(ValueKind::Number(joined_len as f64), Range::ORIGIN))
+    Ok(Value::new(ValueKind::Number(str_len as f64), *location))
 }
 
-fn get_type(location: &Range, args: &Vec<Value>, _stdouts: &mut Stdout) -> ValRes {
-    if args.len() != 1 {
-        return Err(EvalError::new(EvalErrorKind::BadNumArgs, *location));
-    }
-
-    let arg = &args[0];
+fn get_type(location: &Range, env: &Env, _stdouts: &mut Stdout) -> ValRes {
+    let arg = env.get("값").unwrap();
     let arg_type = match arg.kind {
         ValueKind::Bool(_) => "불리언",
         ValueKind::Number(_) => "숫자",

--- a/komi_evaluator/src/environment/mod.rs
+++ b/komi_evaluator/src/environment/mod.rs
@@ -1,7 +1,4 @@
-use komi_syntax::value::Value;
-use komi_util;
-
-pub type Environment = komi_util::environment::Environment<Value>;
+pub use komi_syntax::value::Environment;
 
 #[cfg(test)]
 mod tests {

--- a/komi_syntax/src/error/eval/mod.rs
+++ b/komi_syntax/src/error/eval/mod.rs
@@ -44,6 +44,10 @@ pub enum EvalErrorKind {
     NonBoolPred,
     /// The number of arguments is not the same with the one of parameters.
     BadNumArgs,
+    /// Expected a closure value as a right-hand side operand of a dot infix, but it isn't.
+    NotClosureRightOperand,
+    /// Expected a closure with non-empty parameters as a right-hand side operand of a dot infix, but it isn't.
+    NoParamsToBind,
 }
 
 pub type EvalError = EngineError<EvalErrorKind>;
@@ -71,6 +75,8 @@ impl fmt::Display for EvalErrorKind {
             EvalErrorKind::InvalidCallTarget => "InvalidCallTarget",
             EvalErrorKind::NonBoolPred => "NonBoolPred",
             EvalErrorKind::BadNumArgs => "BadNumArgs",
+            EvalErrorKind::NotClosureRightOperand => "NotClosureRightOperand",
+            EvalErrorKind::NoParamsToBind => "NoParamsToBind",
         };
         write!(f, "{}", s)
     }

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -2,9 +2,12 @@ mod representation;
 
 use crate::ast::Ast;
 use crate::error::EvalError;
-use komi_util::environment::Environment;
+// TODO: separate environment from this file (is environment syntax?)
+use komi_util::environment::Environment as BaseEnvironment;
 use komi_util::location::Range;
 use representation::Representer;
+
+pub type Environment = BaseEnvironment<Value>;
 
 /// Kinds of values produced during evaluation.
 /// Serves as the interface between an evaluator and its user.
@@ -16,7 +19,7 @@ pub enum ValueKind {
     Closure {
         parameters: Vec<String>,
         body: ClosureBodyKind,
-        env: Environment<Value>,
+        env: Environment,
     },
 }
 

--- a/komi_syntax/src/value/mod.rs
+++ b/komi_syntax/src/value/mod.rs
@@ -43,7 +43,7 @@ impl Value {
 }
 
 pub type Stdout = Vec<String>;
-pub type BuiltinFunc = fn(&Range, &Vec<Value>, &mut Stdout) -> Result<Value, EvalError>;
+pub type BuiltinFunc = fn(&Range, &Environment, &mut Stdout) -> Result<Value, EvalError>;
 
 #[macro_export]
 macro_rules! mkval {

--- a/komi_util/src/environment/mod.rs
+++ b/komi_util/src/environment/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 /// A lexical environment implemented as a linked list of hash maps.
+// TODO: separate from util module, so that not visible and not used in engine modules.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Environment<T> {
     outer: Option<Box<Environment<T>>>,


### PR DESCRIPTION
(minor) fix:
- dropped checking the number of arguments in builtin function logic.
  this is already done in call evaluation, and wrong when called with method syntax.
- changed builtin function type to take environment instead of arguments.
  turns out that what it really needs is environment, because the function knows its parameter names, and can get the arguments from the environment.
- dependency of environment data structure: evaluator imports the environment from value module, instead of utility module. however, it seems that it still needs to be changed where it belongs.