### PR TITLE
fix method syntax on number

### DIFF
--- a/komi/src/lib.rs
+++ b/komi/src/lib.rs
@@ -392,6 +392,7 @@ mod tests {
     #[rstest]
     #[case::str_and_closure("\"사과\".함수 문자1, 문자2 { 문자1+문자2 }(\"오렌지\")", "사과오렌지", "")]
     #[case::str_and_builtin("\"사과\".타입()", "문자", "")]
+    #[case::str_and_builtin("1.타입()", "숫자", "")]
     fn method(#[case] source: &str, #[case] expected_repr: String, #[case] expected_stdout: String) {
         assert_out!(source, expected_repr, expected_stdout);
     }

--- a/komi_lexer/src/lexer_tool/num/mod.rs
+++ b/komi_lexer/src/lexer_tool/num/mod.rs
@@ -8,35 +8,52 @@ use komi_util::scanner::Scanner;
 ///
 /// Call this after advancing the scanner past the initial character, with its location passed as `first_location`.
 /// The scanner stops at the first non-digit character, after reading a number with or without a decimal part.
-pub fn lex_num(scanner: &mut SourceScanner, first_location: Range, first_char: &str) -> TokenRes {
+// TODO: spilt into sub functions and use match to simplify representation of the logic
+pub fn lex_num(
+    scanner: &mut SourceScanner,
+    pushback_buffer: &mut Vec<(&str, Range)>,
+    first_location: Range,
+    first_char: &str,
+) -> TokenRes {
     let mut lexeme = String::new();
     let begin = first_location.begin;
 
     // Read the whole number part
     lexeme.push_str(&read_digits(scanner, first_char));
+    let whole_part_end = scanner.locate().begin;
 
     // Return a token if not a dot
     let Some(".") = scanner.read() else {
-        let end = scanner.locate().begin;
-        let token = lex_num_lexeme(lexeme, Range::new(begin, end));
+        let token = lex_num_lexeme(lexeme, Range::new(begin, whole_part_end));
 
         return Ok(token);
     };
 
-    // Read a dot
+    // Advance past the dot
+    let dot_location = scanner.locate();
     scanner.advance();
-    lexeme.push_str(".");
 
     // Return an error if end or not a digit, to prohibit invalid literals such as `12.` or `12.+`
     let Some(x) = scanner.read() else {
         let location = Range::new(begin, scanner.locate().end);
         return Err(LexError::new(LexErrorKind::IllegalNumLiteral, location));
     };
-    if !char_validator::is_digit_char(x) {
+
+    let char_in_id_domain = char_validator::is_char_in_identifier_domain(x);
+    let digit_char = char_validator::is_digit_char(x);
+    if !digit_char && char_in_id_domain {
+        pushback_buffer.push((".", dot_location));
+        let token = lex_num_lexeme(lexeme, Range::new(begin, whole_part_end));
+        return Ok(token);
+    }
+    if !digit_char {
         let location = Range::new(begin, scanner.locate().end);
         return Err(LexError::new(LexErrorKind::IllegalNumLiteral, location));
     }
     scanner.advance();
+
+    // Append the previous dot
+    lexeme.push_str(".");
 
     // Read the decimal part
     lexeme.push_str(&read_digits(scanner, x));
@@ -102,11 +119,18 @@ mod tests {
             Kind::Number(12.25),
         )
     )]
+    #[case::with_decimal(
+        "12.사과",
+        mktoken!(str_loc!("", "12"),
+            Kind::Number(12.0),
+        )
+    )]
     fn ok(#[case] source: &str, #[case] expected: Token) {
         let mut scanner = SourceScanner::new(source);
+        let mut pushback_buffer = vec![];
         let first_char = scanner.read_and_advance().unwrap();
 
-        let token = lex_num(&mut scanner, range(), first_char);
+        let token = lex_num(&mut scanner, &mut pushback_buffer, range(), first_char);
 
         assert_eq!(token, Ok(expected));
     }


### PR DESCRIPTION
fixed lexing to tokenize identifiers after number and dot.
for example, now correctly tokenizes `1.foo`, instead of returning error for invalid number literal.

since lexing `1.foo` requires two lookaheads, added pushback buffer to lexer to store the dot previously read.